### PR TITLE
로그인시 JWT 인증 오류 버그 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
@@ -75,7 +76,11 @@ public class JwtTokenProvider {
 
     // HTTP 헤더에서 Token 값 추출
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("X-AUTH-TOKEN");
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
     // 토큰 유효성 체크


### PR DESCRIPTION
* `JwtTokenProvider.java` 

기존의 구현 방식은 토큰을 `X-AUTH-TOKEN`에 넣어 확인하도록 구현되어 있었는데, JWT는 Authrization 내 Bearer로 넣는 것이 표준이라고 한다. 해당 방식으로 넣었을 때 제대로 작동하도록 고쳐주었다.