### PR TITLE
메인 페이지 - 게시글 호출 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -74,4 +74,8 @@ public class Account {
     public static Account of(String username, String password, AccountRole role) {
         return new Account(null, username, password, role);
     }
+
+    public static Account of(Long id, String username, String password, AccountRole role) {
+        return new Account(id, username, password, role);
+    }
 }

--- a/src/main/java/com/filmdoms/community/post/controller/PostController.java
+++ b/src/main/java/com/filmdoms/community/post/controller/PostController.java
@@ -26,4 +26,11 @@ public class PostController {
                 .map(PostMainPageResponseDto::from)
                 .collect(Collectors.toList()));
     }
+
+    // TODO: 게시글 작성 기능 구현 후 삭제
+    @PostMapping("/test/post")
+    public Response testPost(@RequestParam String title) {
+        postService.testPost(title);
+        return Response.success();
+    }
 }

--- a/src/main/java/com/filmdoms/community/post/controller/PostController.java
+++ b/src/main/java/com/filmdoms/community/post/controller/PostController.java
@@ -1,0 +1,29 @@
+package com.filmdoms.community.post.controller;
+
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.post.data.dto.response.PostMainPageResponseDto;
+import com.filmdoms.community.post.service.PostService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping("/main/post")
+    public Response<List<PostMainPageResponseDto>> viewMain() {
+        return Response.success(postService.getMainPagePosts()
+                .stream()
+                .map(PostMainPageResponseDto::from)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/filmdoms/community/post/controller/PostController.java
+++ b/src/main/java/com/filmdoms/community/post/controller/PostController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class PostController {
 

--- a/src/main/java/com/filmdoms/community/post/data/constants/PostCategory.java
+++ b/src/main/java/com/filmdoms/community/post/data/constants/PostCategory.java
@@ -1,0 +1,8 @@
+package com.filmdoms.community.post.data.constants;
+
+public enum PostCategory {
+    FREE,
+    SHARE,
+    REVIEW,
+    ;
+}

--- a/src/main/java/com/filmdoms/community/post/data/dto/PostBriefDto.java
+++ b/src/main/java/com/filmdoms/community/post/data/dto/PostBriefDto.java
@@ -1,0 +1,42 @@
+package com.filmdoms.community.post.data.dto;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.post.data.constants.PostCategory;
+import com.filmdoms.community.post.data.entity.Post;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 게시판에서 조회할 땐 Comment 내용을 조회하지 않아도 되므로, DB 조회가 일어나지 않도록 했다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostBriefDto {
+
+    private Long id;
+    private AccountDto accountDto;
+    private PostCategory postCategory;
+    private String title;
+    private String content;
+    private Integer view;
+    private Integer postCommentsCount;
+    private Timestamp dateCreated;
+    private Timestamp dateLastModified;
+
+    public static PostBriefDto from(Post entity) {
+        return new PostBriefDto(
+                entity.getId(),
+                AccountDto.from(entity.getAccount()),
+                entity.getPostCategory(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getView(),
+                entity.getPostComments().size(),
+                entity.getDateCreated(),
+                entity.getDateLastModified()
+        );
+    }
+}

--- a/src/main/java/com/filmdoms/community/post/data/dto/PostDetailDto.java
+++ b/src/main/java/com/filmdoms/community/post/data/dto/PostDetailDto.java
@@ -1,0 +1,42 @@
+package com.filmdoms.community.post.data.dto;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.post.data.constants.PostCategory;
+import com.filmdoms.community.post.data.entity.Post;
+import com.filmdoms.community.postComment.data.dto.PostCommentDto;
+import java.sql.Timestamp;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostDetailDto {
+
+    private Long id;
+    private AccountDto accountDto;
+    private PostCategory postCategory;
+    private String title;
+    private String content;
+    private Integer view;
+    private Set<PostCommentDto> postComments;
+    private Timestamp dateCreated;
+    private Timestamp dateLastModified;
+
+    public static PostDetailDto from(Post entity) {
+        return new PostDetailDto(
+                entity.getId(),
+                AccountDto.from(entity.getAccount()),
+                entity.getPostCategory(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getView(),
+                entity.getPostComments().stream()
+                        .map(PostCommentDto::from)
+                        .collect(Collectors.toUnmodifiableSet()),
+                entity.getDateCreated(),
+                entity.getDateLastModified()
+        );
+    }
+}

--- a/src/main/java/com/filmdoms/community/post/data/dto/response/PostMainPageResponseDto.java
+++ b/src/main/java/com/filmdoms/community/post/data/dto/response/PostMainPageResponseDto.java
@@ -1,0 +1,23 @@
+package com.filmdoms.community.post.data.dto.response;
+
+import com.filmdoms.community.post.data.dto.PostBriefDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostMainPageResponseDto {
+
+    private String category;
+    private String title;
+    private Integer commentsCount;
+
+    public static PostMainPageResponseDto from(PostBriefDto dto) {
+        return new PostMainPageResponseDto(
+                dto.getPostCategory().toString(),
+                dto.getTitle(),
+                dto.getPostCommentsCount()
+        );
+    }
+
+}

--- a/src/main/java/com/filmdoms/community/post/data/entity/Post.java
+++ b/src/main/java/com/filmdoms/community/post/data/entity/Post.java
@@ -1,0 +1,86 @@
+package com.filmdoms.community.post.data.entity;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.post.data.constants.PostCategory;
+import com.filmdoms.community.postComment.data.entity.PostComment;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "post", indexes = {
+        @Index(columnList = "category"),
+        @Index(columnList = "date_created")
+})
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PostCategory postCategory;
+
+    @Setter
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Setter
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "view", nullable = false)
+    private Integer view;
+
+    @OrderBy("dateCreated DESC")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private final Set<PostComment> postComments = new LinkedHashSet<>();
+
+    @Column(name = "date_created")
+    private Timestamp dateCreated;
+
+    @Column(name = "date_last_modified")
+    private Timestamp dateLastModified;
+
+    @PrePersist
+    void dateCreated() {
+        this.dateCreated = Timestamp.from(Instant.now());
+    }
+
+    @PreUpdate
+    void dateLastModified() {
+        this.dateLastModified = Timestamp.from(Instant.now());
+    }
+}

--- a/src/main/java/com/filmdoms/community/post/repository/PostRepository.java
+++ b/src/main/java/com/filmdoms/community/post/repository/PostRepository.java
@@ -1,0 +1,11 @@
+package com.filmdoms.community.post.repository;
+
+import com.filmdoms.community.post.data.entity.Post;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // 메인 페이지 호출시 사용
+    List<Post> findFirst4ByOrderByDateCreated();
+}

--- a/src/main/java/com/filmdoms/community/post/service/PostService.java
+++ b/src/main/java/com/filmdoms/community/post/service/PostService.java
@@ -30,4 +30,18 @@ public class PostService {
                 .map(PostBriefDto::from)
                 .collect(Collectors.toUnmodifiableList());
     }
+
+    // TODO: 게시글 작성 기능 구현 후 삭제
+    public void testPost(String title) {
+        Account testAccount = Account.of(1L, "tester", "testpw", AccountRole.USER);
+        postRepository.save(
+                Post.builder()
+                        .account(testAccount)
+                        .postCategory(PostCategory.FREE)
+                        .title(title)
+                        .content("This is a test post.")
+                        .view(0)
+                        .build()
+        );
+    }
 }

--- a/src/main/java/com/filmdoms/community/post/service/PostService.java
+++ b/src/main/java/com/filmdoms/community/post/service/PostService.java
@@ -1,0 +1,33 @@
+package com.filmdoms.community.post.service;
+
+import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.post.data.constants.PostCategory;
+import com.filmdoms.community.post.data.dto.PostBriefDto;
+import com.filmdoms.community.post.data.entity.Post;
+import com.filmdoms.community.post.repository.PostRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    /**
+     * 메서드 호출시, 최근 게시글 4개를 카테고리에 상관 없이 반환한다.
+     * @return 최근 게시글 4개를 반환한다.
+     */
+    @Transactional(readOnly = true) // 이거 안붙여주면 댓글 개수 셀 때 지연로딩 때문에 오류가 난다.
+    public List<PostBriefDto> getMainPagePosts() {
+
+        return postRepository.findFirst4ByOrderByDateCreated()
+                .stream()
+                .map(PostBriefDto::from)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/src/main/java/com/filmdoms/community/postComment/controller/PostCommentController.java
+++ b/src/main/java/com/filmdoms/community/postComment/controller/PostCommentController.java
@@ -1,0 +1,24 @@
+package com.filmdoms.community.postComment.controller;
+
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.postComment.service.PostCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PostCommentController {
+
+    private final PostCommentService postCommentService;
+
+    // TODO: 댓글 작성 기능 구현 후 삭제
+    @PostMapping("/test/comment")
+    public Response testComment(@RequestParam Long postId) {
+        postCommentService.testComment(postId);
+        return Response.success();
+    }
+}

--- a/src/main/java/com/filmdoms/community/postComment/data/dto/PostCommentDto.java
+++ b/src/main/java/com/filmdoms/community/postComment/data/dto/PostCommentDto.java
@@ -1,0 +1,31 @@
+package com.filmdoms.community.postComment.data.dto;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.postComment.data.entity.PostComment;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostCommentDto {
+
+    private Long id;
+    private Long postId;
+    private AccountDto account;
+    private String content;
+    private Timestamp dateCreated;
+    private Timestamp dateLastModified;
+
+    public static PostCommentDto from(PostComment entity) {
+        return new PostCommentDto(
+                entity.getId(),
+                entity.getPost().getId(),
+                AccountDto.from(entity.getAccount()),
+                entity.getContent(),
+                entity.getDateCreated(),
+                entity.getDateLastModified()
+        );
+    }
+
+}

--- a/src/main/java/com/filmdoms/community/postComment/data/entity/PostComment.java
+++ b/src/main/java/com/filmdoms/community/postComment/data/entity/PostComment.java
@@ -1,0 +1,63 @@
+package com.filmdoms.community.postComment.data.entity;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.post.data.entity.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity
+@Table(name = "post_comment")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "post_id")
+    @ManyToOne(optional = false)
+    private Post post;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(optional = false)
+    private Account account;
+
+    @Setter
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "date_created")
+    private Timestamp dateCreated;
+
+    @Column(name = "date_last_modified")
+    private Timestamp dateLastModified;
+
+    @PrePersist
+    void dateCreated() {
+        this.dateCreated = Timestamp.from(Instant.now());
+    }
+
+    @PreUpdate
+    void dateLastModified() {
+        this.dateLastModified = Timestamp.from(Instant.now());
+    }
+
+}

--- a/src/main/java/com/filmdoms/community/postComment/repository/PostCommentRepository.java
+++ b/src/main/java/com/filmdoms/community/postComment/repository/PostCommentRepository.java
@@ -1,0 +1,8 @@
+package com.filmdoms.community.postComment.repository;
+
+import com.filmdoms.community.postComment.data.entity.PostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
+
+}

--- a/src/main/java/com/filmdoms/community/postComment/service/PostCommentService.java
+++ b/src/main/java/com/filmdoms/community/postComment/service/PostCommentService.java
@@ -1,0 +1,29 @@
+package com.filmdoms.community.postComment.service;
+
+import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.postComment.data.entity.PostComment;
+import com.filmdoms.community.postComment.repository.PostCommentRepository;
+import com.filmdoms.community.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostCommentService {
+
+    private final PostRepository postRepository;
+    private final PostCommentRepository postCommentRepository;
+
+    // TODO: 댓글 작성 기능 구현 후 삭제
+    public void testComment(Long postId) {
+        Account testAccount = Account.of(1L, "tester", "testpw", AccountRole.USER);
+        postCommentRepository.save(
+                PostComment.builder()
+                        .account(testAccount)
+                        .post(postRepository.getReferenceById(postId))
+                        .content("content")
+                        .build()
+        );
+    }
+}

--- a/src/test/java/com/filmdoms/community/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/filmdoms/community/account/controller/AccountControllerTest.java
@@ -47,7 +47,7 @@ public class AccountControllerTest {
         when(accountService.login(username, password)).thenReturn("mockJwtString");
 
         // When & Then
-        mockMvc.perform(post("/api/v1/account/login")
+        mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(new LoginRequestDto(username, password)))
                 ).andDo(print())
@@ -67,7 +67,7 @@ public class AccountControllerTest {
         );
 
         // When & Then
-        mockMvc.perform(post("/api/v1/account/login")
+        mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(new LoginRequestDto(username, password)))
                 ).andDo(print())
@@ -86,7 +86,7 @@ public class AccountControllerTest {
         );
 
         // When & Then
-        mockMvc.perform(post("/api/v1/account/login")
+        mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(new LoginRequestDto(username, password)))
                 ).andDo(print())

--- a/src/test/java/com/filmdoms/community/post/controller/PostControllerTest.java
+++ b/src/test/java/com/filmdoms/community/post/controller/PostControllerTest.java
@@ -1,0 +1,73 @@
+package com.filmdoms.community.post.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filmdoms.community.account.config.SecurityConfig;
+import com.filmdoms.community.post.data.constants.PostCategory;
+import com.filmdoms.community.post.data.dto.PostBriefDto;
+import com.filmdoms.community.post.service.PostService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = PostController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+@DisplayName("컨트롤러 - 게시글 서비스")
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private PostService postService;
+
+    @Test
+    @DisplayName("메인 페이지에서 게시글 조회시, 최근 게시글 4개를 반환한다.")
+    void givenNothing_whenViewingPostsFromMainPage_thenReturnsFourRecentPosts() throws Exception {
+
+        // Given
+        given(postService.getMainPagePosts()).willReturn(getMockPostBriefDtos());
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/main/post"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
+                .andExpect(jsonPath("$[?(@.result.length() == 4)]").exists())
+                .andExpect(jsonPath("$[?(@.result.length() == 3)]").doesNotExist());
+    }
+
+    public List<PostBriefDto> getMockPostBriefDtos() {
+        return List.of(
+                PostBriefDto.builder().title("title1").postCategory(PostCategory.FREE).postCommentsCount(5).build(),
+                PostBriefDto.builder().title("title2").postCategory(PostCategory.SHARE).postCommentsCount(10).build(),
+                PostBriefDto.builder().title("title3").postCategory(PostCategory.REVIEW).postCommentsCount(15).build(),
+                PostBriefDto.builder().title("title4").postCategory(PostCategory.FREE).postCommentsCount(20).build()
+        );
+    }
+
+}

--- a/src/test/java/com/filmdoms/community/post/controller/PostControllerTest.java
+++ b/src/test/java/com/filmdoms/community/post/controller/PostControllerTest.java
@@ -44,7 +44,7 @@ class PostControllerTest {
         given(postService.getMainPagePosts()).willReturn(getMockPostBriefDtos());
 
         // When & Then
-        mockMvc.perform(get("/api/main/post"))
+        mockMvc.perform(get("/api/v1/main/post"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/filmdoms/community/post/controller/PostControllerTest.java
+++ b/src/test/java/com/filmdoms/community/post/controller/PostControllerTest.java
@@ -1,20 +1,12 @@
 package com.filmdoms.community.post.controller;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.filmdoms.community.account.config.SecurityConfig;
 import com.filmdoms.community.post.data.constants.PostCategory;
 import com.filmdoms.community.post.data.dto.PostBriefDto;
@@ -52,7 +44,7 @@ class PostControllerTest {
         given(postService.getMainPagePosts()).willReturn(getMockPostBriefDtos());
 
         // When & Then
-        mockMvc.perform(get("/api/v1/main/post"))
+        mockMvc.perform(get("/api/main/post"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/filmdoms/community/post/service/PostServiceTest.java
+++ b/src/test/java/com/filmdoms/community/post/service/PostServiceTest.java
@@ -1,0 +1,89 @@
+package com.filmdoms.community.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+import com.filmdoms.community.account.config.SecurityConfig;
+import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.post.data.constants.PostCategory;
+import com.filmdoms.community.post.data.dto.PostBriefDto;
+import com.filmdoms.community.post.data.entity.Post;
+import com.filmdoms.community.post.repository.PostRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@WebMvcTest(
+        controllers = PostService.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+@DisplayName("비즈니스 로직 - 회원 서비스")
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @MockBean
+    PostRepository postRepository;
+
+    @Test
+    @DisplayName("최근 게시글 조회를 요청하면, 최근 게시글을 4개 반환한다.")
+    void givenNothing_whenSearchingRecentPosts_thenReturnsRecentPosts() {
+        // Given
+        given(postRepository.findFirst4ByOrderByDateCreated()).willReturn(getMockPosts());
+
+        // When
+        List<PostBriefDto> postBriefDtos = postService.getMainPagePosts();
+
+        // Then
+        assertThat(postBriefDtos).isNotEmpty();
+        assertThat(postBriefDtos.size()).isEqualTo(4);
+    }
+
+
+    public List<Post> getMockPosts() {
+        Account testAccount = Account.of(1L, "tester", "testpw", AccountRole.USER);
+        return List.of(
+                Post.builder()
+                        .account(testAccount)
+                        .postCategory(PostCategory.FREE)
+                        .title("test post1")
+                        .content("This is a test post.")
+                        .view(0)
+                        .build(),
+                Post.builder()
+                        .account(testAccount)
+                        .postCategory(PostCategory.FREE)
+                        .title("test post2")
+                        .content("This is a test post.")
+                        .view(0)
+                        .build(),
+                Post.builder()
+                        .account(testAccount)
+                        .postCategory(PostCategory.FREE)
+                        .title("test post3")
+                        .content("This is a test post.")
+                        .view(0)
+                        .build(),
+                Post.builder()
+                        .account(testAccount)
+                        .postCategory(PostCategory.FREE)
+                        .title("test post4")
+                        .content("This is a test post.")
+                        .view(0)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
메인 페이지에서 보여질 최근 게시물들을 불러오는 API를 작성했습니다.
다음 API를 사용할 수 있습니다.

* GET "/api/v1/main/post"
  최근 게시물 4개를 불러옵니다.
* POST "api/v1/test/post?title={게시글 제목}"
  {게시글 제목} 을 제목으로 테스트용 게시글을 하나 생성합니다.
* POST "api/v1/test/post?postId={게시글 ID}"
  {게시글 ID} 를 가진 게시글에 테스트용 댓글을 하나 생성합니다.