### PR TITLE
없는 URI 요청도 상태코드 403으로 처리되는 버그 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
@@ -35,8 +35,7 @@ public class SecurityConfig {
                         // localhost:8080/h2-console 사용하기 위한 설정
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/login", "/join", "/api/**").permitAll()
-
-                        .anyRequest().authenticated())
+                        .anyRequest().permitAll())
 
                 // H2 DB 사용을 위해, x-frame-options 동일 출처 허용
                 .headers(headers -> headers.frameOptions().disable())

--- a/src/main/java/com/filmdoms/community/account/exception/CustomErrorController.java
+++ b/src/main/java/com/filmdoms/community/account/exception/CustomErrorController.java
@@ -1,0 +1,17 @@
+package com.filmdoms.community.account.exception;
+
+import com.filmdoms.community.account.data.dto.response.Response;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class CustomErrorController implements ErrorController {
+
+    @RequestMapping(value = "/error")
+    public ResponseEntity<?> error() {
+        return ResponseEntity.status(ErrorCode.URI_NOT_FOUND.getStatus())
+                .body(Response.error(ErrorCode.URI_NOT_FOUND.name()));
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류가 발생했습니다."),
+    AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    URI_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI가 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 jwt:
   secret-key: ${JWT_KEY}
-
+server:
+  error:
+    whitelabel:
+      enabled: false
 ---
 
 


### PR DESCRIPTION
기존 `.anyRequest().authenticated()` 방법은 존재하지 않는 URI로 요청이 들어온 경우, 요청이 JWT 인증 필터를 통과하였더라도 `CustomAuthenticationEntryPoint` 에서 예외 핸들링이 되도록 처리되었고, 때문에 404 NOT FOUND 가 아닌 403 UNAUTHORIZED 가 반환 됐습니다.
따라서 없는 URI에 대한 요청들이 인증 필터를 타지 않도록 `.anyRequest().permitAll()`로 수정해주었습니다.

그 외에도, 존재하지 않는 URI에 대한 요청들은 기본적으로 "/error" 로 리다이렉트 되도록 설계 되어 있습니다. 해당 리디렉션을 프로젝트에 설계된 API 응답 형식에 맞게 404 NOT FOUND 코드를 내려주기 위해, 컨트롤러 클래스를 작성했고, application.yaml 에 server.error.whitelabel.enabled에 대한 옵션을 false 로 바꾸어주었습니다.