### PR TITLE
프론트엔드에서 API를 호출해볼 수 있도록 dev 환경의 서버 띄우기

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,48 @@ server:
       enabled: false
 ---
 
+spring:
+  config:
+    activate:
+      on-profile: default
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:account;MODE=MySQL;
+    username: SA
+
+cloud:
+  aws:
+    credentials:
+      accessKey:  ${AWS_ACCESS_KEY_ID}
+      secretKey:  ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: ${BUCKET_NAME}
+      dir: /image
+    region:
+      static: ap-northeast-2
+
+    stack:
+      auto: false
+
+
+---
 
 # 로컬 환경에서 테스트시 사용할 프로파일
 # CommunityApplication 을 우클릭하고, [그 외 실행/디버그], [실행 구성 수정] 선택 후에, 활성화된 프로파일에 local을 입력한다.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,28 +9,24 @@ server:
 spring:
   config:
     activate:
-      on-profile: default
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+      on-profile: dev
 
   jpa:
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
-    database-platform: org.hibernate.dialect.H2Dialect
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:account;MODE=MySQL;
-    username: SA
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://${DB_HOST}:${DB_PORT}/filmdoms
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
 cloud:
   aws:
@@ -77,8 +73,8 @@ spring:
   datasource:
     driver-class-name: org.h2.Driver
     # JDBC URL을 jdbc:h2:mem:account 로 설정후 Connect를 누르면 DB에 접근 가능
-    url: jdbc:h2:tcp://localhost/~/account
-    #jdbc:h2:mem:account;MODE=MySQL;
+    url: jdbc:h2:mem:account;MODE=MySQL;
+    #jdbc:h2:tcp://localhost/~/account
     username: SA
     password:
 


### PR DESCRIPTION
클라우드 타입에서 dev 환경의 서버를 띄울 수 있도록 `application.yaml`에 dev 프로필을 추가해주었습니다.

해당 서버에서 사용하는 DB는 MariaDB로, 역시 CloudType에서 운영중입니다.