### PR TITLE
메인 페이지 공지 호출/공지 생성 기능 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류가 발생했습니다."),
     AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     URI_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI가 존재하지 않습니다."),
+    NO_MAIN_IMAGE_ERROR(HttpStatus.BAD_REQUEST, "메인 이미지가 전송되지 않았습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/filmdoms/community/board/notice/controller/NoticeController.java
+++ b/src/main/java/com/filmdoms/community/board/notice/controller/NoticeController.java
@@ -1,0 +1,41 @@
+package com.filmdoms.community.board.notice.controller;
+
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestDto;
+import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
+import com.filmdoms.community.board.notice.data.dto.response.NoticeMainPageDto;
+import com.filmdoms.community.board.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("/main-page")
+    public Response<List<NoticeMainPageDto>> mainPageNotice() {
+        List<NoticeMainPageDto> dtos = noticeService.getMainPageDtos();
+        return Response.success(dtos);
+    }
+
+    @PostMapping("/create")
+    public Response<NoticeCreateResponseDto> create(@RequestPart("data") NoticeCreateRequestDto requestDto, @RequestPart(value = "mainImage", required = false) MultipartFile mainImageFile, @RequestPart(value = "subImage", required = false) List<MultipartFile> subImageFiles) throws IOException {
+        NoticeCreateResponseDto responseDto = noticeService.create(requestDto, mainImageFile, subImageFiles);
+        return Response.success(responseDto);
+    }
+
+    @PostMapping("/init-data")
+    public Response initData() throws InterruptedException {
+        noticeService.initData();
+        return Response.success();
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/dto/request/NoticeCreateRequestDto.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/dto/request/NoticeCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.filmdoms.community.board.notice.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class NoticeCreateRequestDto {
+
+    private String title;
+    private Long accountId;
+    private String content;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeCreateResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeCreateResponseDto.java
@@ -1,0 +1,16 @@
+package com.filmdoms.community.board.notice.data.dto.response;
+
+import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NoticeCreateResponseDto {
+
+    private Long postId;
+
+    public NoticeCreateResponseDto(NoticeHeader header) {
+        this.postId = header.getId();
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeMainPageDto.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeMainPageDto.java
@@ -1,0 +1,30 @@
+package com.filmdoms.community.board.notice.data.dto.response;
+
+import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@AllArgsConstructor
+@Getter
+public class NoticeMainPageDto {
+
+    private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd";
+
+    private String title;
+    private String mainImageUrl;
+    private String startDate;
+    private String endDate;
+
+    public NoticeMainPageDto(NoticeHeader noticeHeader) {
+        this.title = noticeHeader.getTitle();
+
+        //지연로딩 일어나는 부분 -> 나중에 최적화
+        this.mainImageUrl = noticeHeader.getImageFiles().get(0).getFileUrl();
+
+        //메인 페이지에서는 날짜 정보만 출력하므로 시간 정보는 생략
+        this.startDate = noticeHeader.getStartDate().format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN));
+        this.endDate = noticeHeader.getEndDate().format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN));
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/entity/NoticeHeader.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/entity/NoticeHeader.java
@@ -1,0 +1,37 @@
+package com.filmdoms.community.board.notice.data.entity;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.board.data.BoardContent;
+import com.filmdoms.community.board.data.BoardHeadCore;
+import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "notice_header")
+@DiscriminatorValue("NoticeHeader")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class NoticeHeader extends BoardHeadCore {
+
+    @OneToMany(mappedBy = "boardHeadCore", cascade = CascadeType.REMOVE)
+    private List<ImageFile> imageFiles = new ArrayList<>();
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    @Builder
+    private NoticeHeader(String title, Account author, BoardContent boardContent, LocalDateTime startDate, LocalDateTime endDate) {
+        super(title, author, boardContent);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/repository/NoticeHeaderRepository.java
+++ b/src/main/java/com/filmdoms/community/board/notice/repository/NoticeHeaderRepository.java
@@ -1,0 +1,11 @@
+package com.filmdoms.community.board.notice.repository;
+
+import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NoticeHeaderRepository extends JpaRepository<NoticeHeader, Long> {
+
+    List<NoticeHeader> findTop4ByOrderByDateCreatedDesc();
+}

--- a/src/main/java/com/filmdoms/community/board/notice/service/NoticeService.java
+++ b/src/main/java/com/filmdoms/community/board/notice/service/NoticeService.java
@@ -72,7 +72,6 @@ public class NoticeService {
         }
     }
 
-    //추후 수정 필수 (현재 메인 이미지 파일은 noticeHeader.mainImage와 일대일 매핑 상태, noticeHeader.imageFiles와 연관 관계가 맺어지지 않음)
     public NoticeCreateResponseDto create(NoticeCreateRequestDto requestDto, MultipartFile mainImageMultipartFile, List<MultipartFile> subImageMultipartFiles) throws IOException {
         //인증 로직 필요
 

--- a/src/main/java/com/filmdoms/community/board/notice/service/NoticeService.java
+++ b/src/main/java/com/filmdoms/community/board/notice/service/NoticeService.java
@@ -1,0 +1,102 @@
+package com.filmdoms.community.board.notice.service;
+
+import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.board.data.BoardContent;
+import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestDto;
+import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
+import com.filmdoms.community.board.notice.data.dto.response.NoticeMainPageDto;
+import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
+import com.filmdoms.community.board.notice.repository.NoticeHeaderRepository;
+import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
+import com.filmdoms.community.imagefile.repository.ImageFileRepository;
+import com.filmdoms.community.imagefile.service.ImageFileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeHeaderRepository noticeHeaderRepository;
+    private final AccountRepository accountRepository;
+    private final ImageFileRepository imageFileRepository; //테스트 메서드에 필요 (나중에 삭제)
+    private final ImageFileService imageFileService;
+
+    public List<NoticeMainPageDto> getMainPageDtos() {
+        return noticeHeaderRepository.findTop4ByOrderByDateCreatedDesc()
+                .stream()
+                .map(NoticeMainPageDto::new)
+                .collect(Collectors.toList());
+    }
+
+    //임시 데이터 생성 메서드 -> 나중에 삭제할 것
+    public void initData() throws InterruptedException {
+        Account author = Account.of("noticeUser", "1234", AccountRole.USER);
+        accountRepository.save(author);
+
+        //임시 데이터 생성에 필요한 테스트 이미지 url
+        String testImageUrl = "https://filmdomsimage.s3.ap-northeast-2.amazonaws.com/124a71f5-0949-4eb5-b6fc-dacb6a67a010-123123.png";
+
+        for (int i = 0; i < 5; i++) {
+            BoardContent content = BoardContent.builder()
+                    .content("test notice content")
+                    .build();
+
+            NoticeHeader header = NoticeHeader.builder()
+                    .title("notice " + i)
+                    .author(author)
+                    .boardContent(content)
+                    .startDate(LocalDateTime.of(2023, 3, i + 1, 18, 0, 0))
+                    .endDate(LocalDateTime.of(2023, 4, i + 1, 18, 0, 0))
+                    .build();
+
+            noticeHeaderRepository.save(header);
+            imageFileRepository.save(new ImageFile(UUID.randomUUID().toString(), "file" + i + ".png", testImageUrl, header));
+
+            Thread.sleep(10);
+        }
+    }
+
+    //추후 수정 필수 (현재 메인 이미지 파일은 noticeHeader.mainImage와 일대일 매핑 상태, noticeHeader.imageFiles와 연관 관계가 맺어지지 않음)
+    public NoticeCreateResponseDto create(NoticeCreateRequestDto requestDto, MultipartFile mainImageMultipartFile, List<MultipartFile> subImageMultipartFiles) throws IOException {
+        //인증 로직 필요
+
+        Account author = accountRepository.findById(requestDto.getAccountId())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        BoardContent boardContent = BoardContent.builder()
+                .content(requestDto.getContent())
+                .build();
+
+        NoticeHeader header = NoticeHeader.builder()
+                .title(requestDto.getTitle())
+                .author(author)
+                .boardContent(boardContent)
+                .startDate(requestDto.getStartDate())
+                .endDate(requestDto.getEndDate())
+                .build();
+
+        NoticeHeader savedHeader = noticeHeaderRepository.save(header);
+
+        imageFileService.saveImage(mainImageMultipartFile, header)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.NO_MAIN_IMAGE_ERROR));
+        imageFileService.saveImages(subImageMultipartFiles, header);
+
+        return new NoticeCreateResponseDto(savedHeader);
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/review/data/entity/MovieReviewHeader.java
+++ b/src/main/java/com/filmdoms/community/board/review/data/entity/MovieReviewHeader.java
@@ -27,7 +27,7 @@ public class MovieReviewHeader extends BoardHeadCore {
     @OneToMany(mappedBy = "header", cascade = CascadeType.REMOVE)
     private List<MovieReviewComment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "boardHeadCore")
+    @OneToMany(mappedBy = "boardHeadCore", cascade = CascadeType.REMOVE)
     private List<ImageFile> imageFiles = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
@@ -2,17 +2,19 @@ package com.filmdoms.community.imagefile.data.entitiy;
 
 
 import com.filmdoms.community.board.data.BaseTimeEntity;
-import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.data.BoardHeadCore;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Entity
 @RequiredArgsConstructor
+@Getter
 public class ImageFile extends BaseTimeEntity {
 
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     String originalFileName;
     String uuidFileName;


### PR DESCRIPTION
* 메인 페이지 공지 호출 API
GET /api/v1/notice/main-page
공지 데이터 json 응답 형식 예시는 아래와 같습니다. 생성일 내림차순으로 최대 4건 호출됩니다.
{ "title": "공지 제목", "mainImageUrl": "메인 이미지 url", "startDate": "2023-03-01", "endDate": "2023-04-01" }

* 공지 생성 API 
POST /api/v1/notice/create 에 form-data 형식으로 요청
postman 요청 예시)
key : data (TEXT), value : { "title" : "공지 제목", "accountId" : "1", "content" : "공지 글 내용", "startDate" : "2023-03-01T18:00:00", "endDate" : "2023-04-01T00:00:00" }
key : mainImage (FILE), value : 메인 이미지 파일 첨부
key : subImage (FILE), value : 서브 이미지 파일1 첨부
key : subImage (FILE), value : 서브 이미지 파일2 첨부
...

  * 메인 이미지는 필수이므로 첨부하지 않으면 런타임 에러가 발생합니다. (상태코드 400)
  * 서브 이미지는 여러 장 첨부할 수 있으며 key를 "subImage"로 동일하게 유지하면 됩니다.
  * 리뷰 생성에 필요한 accountId에 해당하는 유저는 미리 생성되어 있어야 합니다.
  * 인증 로직은 아직 구현하지 않은 상태입니다.

* 임시데이터 생성 API
GET /api/v1/notice/init-data
임시 데이터가 5건 생성됩니다.