### PR TITLE
CriticService 에서 ImageFile 사용 오류 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/board/critic/service/CriticBoardService.java
+++ b/src/main/java/com/filmdoms/community/board/critic/service/CriticBoardService.java
@@ -1,51 +1,47 @@
 package com.filmdoms.community.board.critic.service;
 
-import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.dto.response.Response;
-import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.board.critic.data.dto.request.post.CriticBoardPostRequestDto;
-import com.filmdoms.community.board.critic.data.dto.request.post.CriticBoardUpdateRequestDto;
 import com.filmdoms.community.board.critic.data.dto.response.CriticBoardGetResponseDto;
 import com.filmdoms.community.board.critic.data.entity.CriticBoardHeader;
 import com.filmdoms.community.board.critic.repository.CriticBoardHeaderRepository;
 import com.filmdoms.community.board.data.BoardContent;
+import com.filmdoms.community.imagefile.data.dto.ImageFileDto;
+import com.filmdoms.community.imagefile.data.dto.UploadedFileDto;
 import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
 import com.filmdoms.community.imagefile.repository.ImageFileRepository;
-import com.filmdoms.community.imagefile.service.AmazonS3Upload;
-import jakarta.annotation.PostConstruct;
+import com.filmdoms.community.imagefile.service.AmazonS3UploadService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class CriticBoardService {
 
-        private final AccountRepository accountRepository;
-        private final CriticBoardHeaderRepository criticBoardHeaderRepository;
-        private final ImageFileRepository imageFileRepository;
-        private final AmazonS3Upload amazonS3Upload;
+    @Value("${domain}")
+    private String domain;
+    private final AccountRepository accountRepository;
+    private final CriticBoardHeaderRepository criticBoardHeaderRepository;
+    private final ImageFileRepository imageFileRepository;
+    private final AmazonS3UploadService amazonS3UploadService;
 
-        @PersistenceContext
-        private  final EntityManager em;
+    @PersistenceContext
+    private final EntityManager em;
 
 
-
-        public Response writeCritic(CriticBoardPostRequestDto dto, List<MultipartFile> multipartFileList) {
+    public Response writeCritic(CriticBoardPostRequestDto dto, List<MultipartFile> multipartFileList) {
 
         log.info("영화 작성 시작");
 
@@ -58,31 +54,27 @@ public class CriticBoardService {
                         .orElseThrow(() -> new ApplicationException(ErrorCode.URI_NOT_FOUND)))
                 .build();
 
-
         log.info("영화 작성 시작2");
 
         criticBoardHeaderRepository.save(criticBoardHeader);
 
-
         List<String> urlList = new ArrayList<>();
-        if(multipartFileList != null)
-        {
+        if (multipartFileList != null) {
             log.info("멑티파일리스트");
             multipartFileList.stream().forEach(multipartFile ->
             {
                 String originalFileName = null;
-                String uuidFileName = UUID.randomUUID().toString();
                 originalFileName = multipartFile.getOriginalFilename();
-                log.info("멀티파트리스트 사이즈{}",multipartFileList.size());
-                String url = null;
-                try {
-                    url = amazonS3Upload.upload(multipartFile, uuidFileName, originalFileName);
-                    ImageFile imageFile = ImageFile.from(uuidFileName, originalFileName,criticBoardHeader, url);
-                    imageFileRepository.save(imageFile);
-                    if(url!=null)
-                        log.info("파일 업로드 성공");
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+                log.info("멀티파트리스트 사이즈{}", multipartFileList.size());
+                UploadedFileDto uploadedFileDto = null;
+                uploadedFileDto = amazonS3UploadService.upload(multipartFile, originalFileName);
+                imageFileRepository.save(ImageFile.builder()
+                        .uuidFileName(uploadedFileDto.getUuidFileName())
+                        .originalFileName(uploadedFileDto.getOriginalFileName())
+                        .boardHeadCore(criticBoardHeader)
+                        .build());
+                if (uploadedFileDto.getUrl() != null) {
+                    log.info("파일 업로드 성공");
                 }
 
 
@@ -90,14 +82,12 @@ public class CriticBoardService {
 
         }
 
-
         return Response.success("sucess했음");
 
 
     }
 
-    public List<CriticBoardGetResponseDto> getCriticBoardList()
-    {
+    public List<CriticBoardGetResponseDto> getCriticBoardList() {
         List<CriticBoardHeader> resultBoard = getCriticBoardHeaders();
         List<ImageFile> imageFiles = getImageFiles(resultBoard);
 
@@ -111,8 +101,6 @@ public class CriticBoardService {
 
     }
 
-
-
 //    public Response updateCriticBoard(CriticBoardUpdateRequestDto dto, List<MultipartFile> multipartFiles)
 //    {
 //        TypedQuery<CriticBoardHeader> query = em.createQuery("SELECT c from CriticBoardHeader c join fetch c.boardContent where c.id =:id", CriticBoardHeader.class);
@@ -122,8 +110,7 @@ public class CriticBoardService {
 //        return Response.success(criticBoard);
 //    }
 
-    public String deleteCriticBoard()
-    {
+    public String deleteCriticBoard() {
 
         return "";
     }
@@ -144,15 +131,20 @@ public class CriticBoardService {
         return resultBoard;
     }
 
-    private  void setImageFilesToCriticBoardHeader(List<CriticBoardHeader> resultBoard, List<ImageFile> imageFiles, HashMap<Long, List<String>> imageFileHashMap, List<CriticBoardGetResponseDto> responseDtoList) {
+    private void setImageFilesToCriticBoardHeader(List<CriticBoardHeader> resultBoard, List<ImageFile> imageFiles,
+                                                  HashMap<Long, List<String>> imageFileHashMap,
+                                                  List<CriticBoardGetResponseDto> responseDtoList) {
         //초기 해시맵 셋팅
-        resultBoard.stream().forEach(criticBoardHeader -> imageFileHashMap.put(criticBoardHeader.getId(),new ArrayList<>()));
+        resultBoard.stream()
+                .forEach(criticBoardHeader -> imageFileHashMap.put(criticBoardHeader.getId(), new ArrayList<>()));
         //이미지 파일 모으기
-        imageFiles.stream().forEach(imageFile -> imageFileHashMap.get(imageFile.boardHeadCore.getId()).add(imageFile.getFileUrl()));
+        imageFiles.stream()
+                .map(imageFile -> ImageFileDto.from(imageFile, domain))
+                .forEach(dto -> imageFileHashMap.get(dto.getHeaderId()).add(dto.getFileUrl()));
         //responseDtoList 리스트에 add
-        resultBoard.stream().forEach(criticBoardHeader -> responseDtoList.add( CriticBoardGetResponseDto.from(criticBoardHeader, imageFileHashMap)));
+        resultBoard.stream().forEach(criticBoardHeader -> responseDtoList.add(
+                CriticBoardGetResponseDto.from(criticBoardHeader, imageFileHashMap)));
     }
-
 
 
 }

--- a/src/main/java/com/filmdoms/community/imagefile/data/dto/ImageFileDto.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/dto/ImageFileDto.java
@@ -15,6 +15,7 @@ public class ImageFileDto {
     private Long id;
     private String uuidFileName;
     private String fileUrl;
+    private Long headerId;
 
     public static ImageFileDto from(ImageFile entity, String domain) {
         String fileUrl = domain + "/" + entity.getUuidFileName();
@@ -23,6 +24,7 @@ public class ImageFileDto {
                 .id(entity.getId())
                 .uuidFileName(entity.getUuidFileName())
                 .fileUrl(fileUrl)
+                .headerId(entity.getBoardHeadCore().getId())
                 .build();
     }
 }

--- a/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
@@ -1,12 +1,16 @@
 package com.filmdoms.community.imagefile.data.entitiy;
 
 
-import com.filmdoms.community.board.critic.data.entity.CriticBoardHeader;
 import com.filmdoms.community.board.data.BaseTimeEntity;
 import com.filmdoms.community.board.data.BoardHeadCore;
-
-import jakarta.persistence.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,16 +39,5 @@ public class ImageFile extends BaseTimeEntity {
         this.uuidFileName = uuidFileName;
         this.originalFileName = originalFileName;
         this.boardHeadCore = boardHeadCore;
-    }
-
-    public static ImageFile from(String uuidFileName , String originalFileName, CriticBoardHeader criticBoardHeader, String url)
-    {
-        ImageFile imageFile = ImageFile.builder()
-            .uuidFileName(uuidFileName)
-            .originalFileName(originalFileName)
-            .boardHeadCore(criticBoardHeader)
-            .fileUrl(url)
-            .build();
-        return  imageFile;
     }
 }

--- a/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
@@ -1,5 +1,10 @@
 package com.filmdoms.community.board.notice.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
@@ -8,10 +13,16 @@ import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestD
 import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
 import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
 import com.filmdoms.community.board.notice.repository.NoticeHeaderRepository;
-import com.filmdoms.community.imagefile.service.AmazonS3Upload;
+import com.filmdoms.community.imagefile.data.dto.UploadedFileDto;
+import com.filmdoms.community.imagefile.service.AmazonS3UploadService;
 import com.filmdoms.community.imagefile.service.ImageFileService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -21,16 +32,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 
 @DataJpaTest
 @DisplayName("공지 서비스-리포지토리 통합 테스트")
@@ -49,7 +50,7 @@ class NoticeServiceTest {
     AccountRepository accountRepository;
 
     @MockBean
-    AmazonS3Upload amazonS3Upload;
+    AmazonS3UploadService amazonS3UploadService;
 
     @PersistenceContext
     EntityManager em;
@@ -63,7 +64,8 @@ class NoticeServiceTest {
         LocalDateTime startDate = LocalDateTime.of(2023, 3, 1, 18, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2023, 4, 1, 0, 0, 0);
 
-        NoticeCreateRequestDto requestDto = new NoticeCreateRequestDto("공지 제목", testUser.getId(), "공지 내용", startDate, endDate);
+        NoticeCreateRequestDto requestDto = new NoticeCreateRequestDto("공지 제목", testUser.getId(), "공지 내용", startDate,
+                endDate);
 
         //when
         MultipartFile mainImageMultipartFile = null;
@@ -79,6 +81,9 @@ class NoticeServiceTest {
     public void 메인이미지_서브이미지_있는_공지_생성() throws IOException {
 
         //given
+        UploadedFileDto uploadedFileDto = UploadedFileDto.builder()
+                .uuidFileName("(randomUuidFileName).png")
+                .build();
         Account testUser = accountRepository.save(Account.of("user1", "1234", AccountRole.ADMIN));
 
         //공지 시작일 종료일 설정
@@ -86,21 +91,27 @@ class NoticeServiceTest {
         LocalDateTime endDate = LocalDateTime.of(2023, 4, 1, 0, 0, 0);
 
         //공지 이미지 설정
-        MultipartFile mainImageMultipartFile = new MockMultipartFile("image", "main_image_original_file_name", "image/jpeg", new byte[10]); //파일 크기가 0이면 저장되지 않으므로 10바이트짜리 파일 생성
+        MultipartFile mainImageMultipartFile = new MockMultipartFile("image", "main_image_original_file_name",
+                "image/jpeg", new byte[10]); //파일 크기가 0이면 저장되지 않으므로 10바이트짜리 파일 생성
         List<MultipartFile> subImageMultipartFiles = IntStream.range(0, 5).boxed()
-                .map(i -> (MultipartFile) new MockMultipartFile("subImage", "sub_image_original_file_name_" + i, "image/jpeg", new byte[10]))
+                .map(i -> (MultipartFile) new MockMultipartFile("subImage", "sub_image_original_file_name_" + i,
+                        "image/jpeg", new byte[10]))
                 .collect(Collectors.toList()); //가짜 멀티파트 이미지 5장 생성
 
-        NoticeCreateRequestDto requestDto = new NoticeCreateRequestDto("공지 제목", testUser.getId(), "공지 내용", startDate, endDate);
-        Mockito.when(amazonS3Upload.upload(any(), any(), any())).thenReturn("fileUrl"); //amazonS3Upload 객체에 가짜 행동 주입
+        NoticeCreateRequestDto requestDto = new NoticeCreateRequestDto("공지 제목", testUser.getId(), "공지 내용", startDate,
+                endDate);
+        Mockito.when(amazonS3UploadService.upload(any(), any()))
+                .thenReturn(uploadedFileDto); //amazonS3Upload 객체에 가짜 행동 주입
 
         //when
-        NoticeCreateResponseDto responseDto = noticeService.create(requestDto, mainImageMultipartFile, subImageMultipartFiles);//ApplicationException 발생하지 않아야 함
+        NoticeCreateResponseDto responseDto = noticeService.create(requestDto, mainImageMultipartFile,
+                subImageMultipartFiles);//ApplicationException 발생하지 않아야 함
         em.flush();
         em.clear(); //공지 생성시에는 헤더에 이미지가 들어있지 않으므로 flush, clear 후 다시 불러와야 함
 
         //then
-        NoticeHeader header = headerRepository.findById(responseDto.getPostId()).orElseThrow(() -> new RuntimeException("요청한 포스트 아이디가 존재하지 않음"));
+        NoticeHeader header = headerRepository.findById(responseDto.getPostId())
+                .orElseThrow(() -> new RuntimeException("요청한 포스트 아이디가 존재하지 않음"));
         assertThat(header.getImageFiles().size()).isEqualTo(1 + subImageMultipartFiles.size()); //메인이미지 개수 + 서브이미지 개수
         assertThat(header.getTitle()).isEqualTo(requestDto.getTitle()); //request DTO에서 전달된 값들이 저장되었는지 확인
         assertThat(header.getAuthor().getId()).isEqualTo(testUser.getId());

--- a/src/test/java/com/filmdoms/community/board/post/controller/PostControllerTest.java
+++ b/src/test/java/com/filmdoms/community/board/post/controller/PostControllerTest.java
@@ -1,4 +1,4 @@
-package com.filmdoms.community.post.controller;
+package com.filmdoms.community.board.post.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -52,6 +52,11 @@ class PostControllerTest {
                 .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
                 .andExpect(jsonPath("$[?(@.result.length() == 4)]").exists())
                 .andExpect(jsonPath("$[?(@.result.length() == 3)]").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("메인 페이지에서 게시글 조회시, 최근 게시글 4개를 반환한다.")
+    void givenCreatingPostRequest_whenCreatingPost_thenReturnsCreatedPostId() throws Exception {
     }
 
     public List<PostBriefDto> getMockPostBriefDtos() {

--- a/src/test/java/com/filmdoms/community/board/post/service/PostServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/post/service/PostServiceTest.java
@@ -1,4 +1,4 @@
-package com.filmdoms.community.post.service;
+package com.filmdoms.community.board.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -6,12 +6,14 @@ import static org.mockito.BDDMockito.given;
 import com.filmdoms.community.account.config.SecurityConfig;
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.post.data.constants.PostCategory;
 import com.filmdoms.community.board.post.data.dto.PostBriefDto;
 import com.filmdoms.community.board.post.data.entity.PostHeader;
 import com.filmdoms.community.board.post.repository.PostHeaderRepository;
 import com.filmdoms.community.board.post.service.PostService;
+import com.filmdoms.community.imagefile.service.ImageFileService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,10 @@ class PostServiceTest {
 
     @MockBean
     PostHeaderRepository postHeaderRepository;
+    @MockBean
+    AccountRepository accountRepository;
+    @MockBean
+    ImageFileService imageFileService;
 
     @Test
     @DisplayName("최근 게시글 조회를 요청하면, 최근 게시글을 4개 반환한다.")

--- a/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
@@ -1,5 +1,9 @@
 package com.filmdoms.community.board.review.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
@@ -8,10 +12,15 @@ import com.filmdoms.community.board.review.data.dto.request.MovieReviewCreateReq
 import com.filmdoms.community.board.review.data.dto.response.MovieReviewCreateResponseDto;
 import com.filmdoms.community.board.review.data.entity.MovieReviewHeader;
 import com.filmdoms.community.board.review.repository.MovieReviewHeaderRepository;
-import com.filmdoms.community.imagefile.service.AmazonS3Upload;
+import com.filmdoms.community.imagefile.data.dto.UploadedFileDto;
+import com.filmdoms.community.imagefile.service.AmazonS3UploadService;
 import com.filmdoms.community.imagefile.service.ImageFileService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -21,14 +30,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 
 @DataJpaTest
 @DisplayName("영화 리뷰 서비스-리포지토리 통합 테스트")
@@ -47,7 +48,7 @@ class MovieReviewServiceTest {
     AccountRepository accountRepository;
 
     @MockBean
-    AmazonS3Upload amazonS3Upload;
+    AmazonS3UploadService amazonS3UploadService;
 
     @PersistenceContext
     EntityManager em;
@@ -56,13 +57,15 @@ class MovieReviewServiceTest {
     public void 이미지_없는_영화리뷰_생성() throws IOException {
         //given
         Account testUser = accountRepository.save(Account.of("user1", "1234", AccountRole.USER));
-        MovieReviewCreateRequestDto requestDto = new MovieReviewCreateRequestDto(MovieReviewTag.A, "영화 리뷰 제목", testUser.getId(), "영화 리뷰 내용");
+        MovieReviewCreateRequestDto requestDto = new MovieReviewCreateRequestDto(MovieReviewTag.A, "영화 리뷰 제목",
+                testUser.getId(), "영화 리뷰 내용");
 
         //when
         MovieReviewCreateResponseDto responseDto = movieReviewService.createReview(requestDto, null);
 
         //then
-        MovieReviewHeader header = headerRepository.findById(responseDto.getPostId()).orElseThrow(() -> new RuntimeException("요청한 포스트 아이디가 존재하지 않음"));
+        MovieReviewHeader header = headerRepository.findById(responseDto.getPostId())
+                .orElseThrow(() -> new RuntimeException("요청한 포스트 아이디가 존재하지 않음"));
         assertThat(header.getAuthor().getId()).isEqualTo(testUser.getId()); //request DTO에서 전달된 값들이 저장되었는지 확인
         assertThat(header.getTitle()).isEqualTo(requestDto.getTitle());
         assertThat(header.getTag()).isEqualTo(requestDto.getTag());
@@ -72,14 +75,20 @@ class MovieReviewServiceTest {
     @Test
     public void 이미지_있는_영화리뷰_생성() throws IOException {
         //given
+        UploadedFileDto uploadedFileDto = UploadedFileDto.builder()
+                .uuidFileName("(randomUuidFileName).png")
+                .build();
         //리뷰 이미지 생성
         List<MultipartFile> multipartFiles = IntStream.range(0, 5).boxed()
-                .map(i -> (MultipartFile) new MockMultipartFile("image", "image_original_file_name_" + i, "image/jpeg", new byte[10])) //파일 크기가 0이면 저장되지 않으므로 10바이트짜리 파일 생성
+                .map(i -> (MultipartFile) new MockMultipartFile("image", "image_original_file_name_" + i, "image/jpeg",
+                        new byte[10])) //파일 크기가 0이면 저장되지 않으므로 10바이트짜리 파일 생성
                 .collect(Collectors.toList()); //가짜 멀티파트 이미지 5장 생성
 
         Account testUser = accountRepository.save(Account.of("user1", "1234", AccountRole.USER));
-        MovieReviewCreateRequestDto requestDto = new MovieReviewCreateRequestDto(MovieReviewTag.A, "영화 리뷰 제목", testUser.getId(), "영화 리뷰 내용");
-        Mockito.when(amazonS3Upload.upload(any(), any(), any())).thenReturn("fileUrl"); //amazonS3Upload 객체에 가짜 행동 주입
+        MovieReviewCreateRequestDto requestDto = new MovieReviewCreateRequestDto(MovieReviewTag.A, "영화 리뷰 제목",
+                testUser.getId(), "영화 리뷰 내용");
+        Mockito.when(amazonS3UploadService.upload(any(), any()))
+                .thenReturn(uploadedFileDto); //amazonS3Upload 객체에 가짜 행동 주입
 
         //when
         MovieReviewCreateResponseDto responseDto = movieReviewService.createReview(requestDto, multipartFiles);
@@ -88,7 +97,8 @@ class MovieReviewServiceTest {
 
         //then
         assertThat(multipartFiles).size().isEqualTo(5); //멀티파트 파일은 5개
-        MovieReviewHeader header = headerRepository.findById(responseDto.getPostId()).orElseThrow(() -> new RuntimeException("요청한 포스트 아이디가 존재하지 않음"));
+        MovieReviewHeader header = headerRepository.findById(responseDto.getPostId())
+                .orElseThrow(() -> new RuntimeException("요청한 포스트 아이디가 존재하지 않음"));
         assertThat(header.getImageFiles().size()).isEqualTo(multipartFiles.size()); //헤더에 ImageFile 객체 5개가 연결되었는지 확인
         assertThat(header.getAuthor().getId()).isEqualTo(testUser.getId());
         assertThat(header.getTitle()).isEqualTo(requestDto.getTitle());


### PR DESCRIPTION
ImageFile 에 Url 제거한 변경사항이 CriticService에 적용되지 않아 버그를 일으켰다. 
ImageFile을 ImageFileDto로 변환하여 사용하는 것으로 버그를 고쳤다.

또, S3 업로드 서비스가 Url 스트링이 아닌, Dto를 반환하므로, 해당 수정사항에 맞춰 테스트를 수정했다.