### PR TITLE
게시글 작성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 // Amazon S3 관련 의존성
 	implementation "com.amazonaws:aws-java-sdk-s3:1.12.281"
 	implementation 'javax.xml.bind:jaxb-api:2.3.0'
+// RequestDto 를 검증하는 Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation:2.5.6'
 
 }
 

--- a/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // localhost:8080/h2-console 사용하기 위한 설정
                         .requestMatchers("/h2-console/**").permitAll()
-                        .requestMatchers("/login", "/join", "/api/**").permitAll()
+                        .requestMatchers("/login", "/join").permitAll()
+                        .requestMatchers("/api/v1/post/create").authenticated()
                         .anyRequest().permitAll())
 
                 // H2 DB 사용을 위해, x-frame-options 동일 출처 허용

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/Response.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/Response.java
@@ -14,6 +14,10 @@ public class Response<T> {
         return new Response<>(errorCode, null);
     }
 
+    public static <T> Response<T> error(String errorCode, T result) {
+        return new Response<>(errorCode, result);
+    }
+
     public static Response<Void> success() {
         return new Response<Void>("SUCCESS", null);
     }
@@ -25,12 +29,12 @@ public class Response<T> {
     public String toStream() {
         if (result == null) {
             return "{" +
-                    "\"resultCode\":" + "\"" + resultCode + "\"" +
+                    "\"resultCode\":" + "\"" + resultCode + "\"," +
                     "\"result\":" + null + "}";
         }
 
         return "{" +
-                "\"resultCode\":" + "\"" + resultCode + "\"" +
+                "\"resultCode\":" + "\"" + resultCode + "\"," +
                 "\"result\":" + "\"" + result + "\"" + "}";
     }
 }

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류가 발생했습니다."),
     AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     URI_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI가 존재하지 않습니다."),
+    REQUEST_PARSE_ERROR(HttpStatus.BAD_REQUEST, "요청 파싱 중 오류가 발생했습니다."),
     NO_MAIN_IMAGE_ERROR(HttpStatus.BAD_REQUEST, "메인 이미지가 전송되지 않았습니다."),
     S3_ERROR(HttpStatus.FORBIDDEN, "S3 업로드에 실패했습니다.")
     ;

--- a/src/main/java/com/filmdoms/community/account/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/filmdoms/community/account/exception/GlobalControllerAdvice.java
@@ -1,9 +1,16 @@
 package com.filmdoms.community.account.exception;
 
 import com.filmdoms.community.account.data.dto.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,15 +20,37 @@ public class GlobalControllerAdvice {
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<?> applicationHandler(ApplicationException e) {
-        log.error("Error occurs {}", e.toString());
+        log.error("Error occurs: {}", e.toString());
         return ResponseEntity.status(e.getErrorCode().getStatus())
                 .body(Response.error(e.getErrorCode().name()));
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<?> applicationHandler(RuntimeException e) {
-        log.error("Error occurs {}", e.toString());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        log.error("Error occurs: {}", e.toString());
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(Response.error(ErrorCode.INTERNAL_SERVER_ERROR.name()));
     }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> JsonParseExceptionHandler(
+            HttpMessageNotReadableException e) {
+        log.error("Error occurs: {}", e.toString());
+        return ResponseEntity.status(ErrorCode.REQUEST_PARSE_ERROR.getStatus())
+                .body(Response.error(ErrorCode.REQUEST_PARSE_ERROR.name()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    public ResponseEntity<?> validExceptionHandler(
+            MethodArgumentNotValidException e) {
+        log.error("Error occurs: {}", ErrorCode.REQUEST_PARSE_ERROR.getMessage());
+        // 파싱 중 Validation에 걸린 필드의 예외 메시지를 모두 모읍니다.
+        List<String> errors = e.getBindingResult().getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.toList());
+        return ResponseEntity.status(ErrorCode.REQUEST_PARSE_ERROR.getStatus())
+                .body(Response.error(ErrorCode.REQUEST_PARSE_ERROR.name(), errors));
+    }
 }
+

--- a/src/main/java/com/filmdoms/community/account/exception/ValidationMessage.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ValidationMessage.java
@@ -1,0 +1,10 @@
+package com.filmdoms.community.account.exception;
+
+public class ValidationMessage {
+
+    public static final String TITLE_NOT_BLANK = "제목은 공백일 수 없습니다.";
+    public static final String TITLE_SIZE = "제목은 100자 이내이어야 합니다.";
+    public static final String CONTENT_NOT_BLANK = "본문은 공백일 수 없습니다.";
+    public static final String CONTENT_SIZE = "본문은 10000자 이내이어야 합니다.";
+
+}

--- a/src/main/java/com/filmdoms/community/board/post/controller/PostController.java
+++ b/src/main/java/com/filmdoms/community/board/post/controller/PostController.java
@@ -1,16 +1,25 @@
 package com.filmdoms.community.board.post.controller;
 
+import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.board.post.data.dto.request.PostCreateRequestDto;
+import com.filmdoms.community.board.post.data.dto.response.PostCreateResponseDto;
 import com.filmdoms.community.board.post.data.dto.response.PostMainPageResponseDto;
 import com.filmdoms.community.board.post.service.PostService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/post")
@@ -27,10 +36,15 @@ public class PostController {
                 .collect(Collectors.toList()));
     }
 
-    // TODO: 게시글 작성 기능 구현 후 삭제
-    @PostMapping("/test-data")
-    public Response testPost(@RequestParam String title) {
-        postService.testPost(title);
-        return Response.success();
+    @PostMapping("/create")
+    public Response create(
+            @AuthenticationPrincipal AccountDto accountDto,
+            @RequestPart(value = "data") @Valid PostCreateRequestDto requestDto,
+            @RequestPart(value = "mainImage", required = false) MultipartFile mainImageFile,
+            @RequestPart(value = "subImage", required = false) List<MultipartFile> subImageFiles) {
+        return Response.success(PostCreateResponseDto.from(
+                postService.create(accountDto, requestDto, mainImageFile, subImageFiles)
+        ));
+
     }
 }

--- a/src/main/java/com/filmdoms/community/board/post/data/dto/PostAccountDto.java
+++ b/src/main/java/com/filmdoms/community/board/post/data/dto/PostAccountDto.java
@@ -1,13 +1,13 @@
 package com.filmdoms.community.board.post.data.dto;
 
 import com.filmdoms.community.account.data.entity.Account;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class PostAccountDto {
-
 
     private Long id;
     private String username;
@@ -21,5 +21,18 @@ public class PostAccountDto {
                 entity.getNickname(),
                 entity.getPassword()
         );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PostAccountDto that = (PostAccountDto) o;
+        return Objects.equals(id, that.id) && Objects.equals(username, that.username)
+                && Objects.equals(email, that.email);
     }
 }

--- a/src/main/java/com/filmdoms/community/board/post/data/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/com/filmdoms/community/board/post/data/dto/request/PostCreateRequestDto.java
@@ -1,0 +1,32 @@
+package com.filmdoms.community.board.post.data.dto.request;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.CONTENT_NOT_BLANK;
+import static com.filmdoms.community.account.exception.ValidationMessage.CONTENT_SIZE;
+import static com.filmdoms.community.account.exception.ValidationMessage.TITLE_NOT_BLANK;
+import static com.filmdoms.community.account.exception.ValidationMessage.TITLE_SIZE;
+
+import com.filmdoms.community.board.post.data.constants.PostCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@ToString
+public class PostCreateRequestDto {
+
+    private PostCategory category;
+
+    @NotBlank(message = TITLE_NOT_BLANK)
+    @Size(max = 100, message = TITLE_SIZE)
+    private String title;
+
+    @NotBlank(message = CONTENT_NOT_BLANK)
+    @Size(max = 10000, message = CONTENT_SIZE)
+    private String content;
+}

--- a/src/main/java/com/filmdoms/community/board/post/data/dto/response/PostCreateResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/post/data/dto/response/PostCreateResponseDto.java
@@ -1,0 +1,21 @@
+package com.filmdoms.community.board.post.data.dto.response;
+
+import com.filmdoms.community.board.post.data.dto.PostBriefDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostCreateResponseDto {
+
+    private Long id;
+
+    public static PostCreateResponseDto from(PostBriefDto dto) {
+        return PostCreateResponseDto.builder()
+                .id(dto.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/post/service/PostService.java
+++ b/src/main/java/com/filmdoms/community/board/post/service/PostService.java
@@ -1,25 +1,34 @@
 package com.filmdoms.community.board.post.service;
 
 import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.post.data.constants.PostCategory;
 import com.filmdoms.community.board.post.data.dto.PostBriefDto;
-import com.filmdoms.community.board.post.repository.PostHeaderRepository;
+import com.filmdoms.community.board.post.data.dto.request.PostCreateRequestDto;
 import com.filmdoms.community.board.post.data.entity.PostHeader;
+import com.filmdoms.community.board.post.repository.PostHeaderRepository;
+import com.filmdoms.community.imagefile.service.ImageFileService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
     private final PostHeaderRepository postHeaderRepository;
+    private final AccountRepository accountRepository;
+    private final ImageFileService imageFileService;
 
     /**
      * 메서드 호출시, 최근 게시글 4개를 카테고리에 상관 없이 반환한다.
+     *
      * @return 최근 게시글 4개를 반환한다.
      */
     @Transactional(readOnly = true) // 이거 안붙여주면 댓글 개수 셀 때 지연로딩 때문에 오류가 난다.
@@ -29,6 +38,29 @@ public class PostService {
                 .stream()
                 .map(PostBriefDto::from)
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Transactional
+    public PostBriefDto create(AccountDto accountDto,
+                               PostCreateRequestDto requestDto,
+                               MultipartFile mainImage,
+                               List<MultipartFile> subImages) {
+
+        BoardContent content = BoardContent.builder()
+                .content(requestDto.getContent())
+                .build();
+
+        PostHeader header = postHeaderRepository.save(PostHeader.builder()
+                .category(requestDto.getCategory())
+                .title(requestDto.getTitle())
+                .author(accountRepository.getReferenceById(accountDto.getId()))
+                .content(content)
+                .build());
+
+        imageFileService.saveImage(mainImage, header);
+        imageFileService.saveImages(subImages, header);
+
+        return PostBriefDto.from(header);
     }
 
     // TODO: 게시글 작성 기능 구현 후 삭제

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,48 @@ domain: ${DOMAIN}
 spring:
   config:
     activate:
+      on-profile: test
+
+  jpa:
+    defer-datasource-initialization: false
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:account;MODE=MySQL;
+    username: SA
+    password:
+
+  sql:
+    init:
+      mode: never
+
+cloud:
+  aws:
+    credentials:
+      accessKey:  ${AWS_ACCESS_KEY_ID}
+      secretKey:  ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: ${BUCKET_NAME}
+      dir: /image
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+---
+
+spring:
+  config:
+    activate:
       on-profile: dev
 
   jpa:
@@ -46,7 +88,6 @@ cloud:
       dir: /image
     region:
       static: ap-northeast-2
-
     stack:
       auto: false
 
@@ -68,7 +109,7 @@ spring:
   jpa:
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -98,6 +139,5 @@ cloud:
       dir: /image
     region:
       static: ap-northeast-2
-
     stack:
       auto: false

--- a/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
@@ -31,9 +31,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @DisplayName("공지 서비스-리포지토리 통합 테스트")
 class NoticeServiceTest {
 

--- a/src/test/java/com/filmdoms/community/board/post/controller/PostControllerTest.java
+++ b/src/test/java/com/filmdoms/community/board/post/controller/PostControllerTest.java
@@ -1,43 +1,52 @@
 package com.filmdoms.community.board.post.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.filmdoms.community.account.config.SecurityConfig;
-import com.filmdoms.community.board.post.controller.PostController;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.filmdoms.community.board.post.data.constants.PostCategory;
 import com.filmdoms.community.board.post.data.dto.PostBriefDto;
+import com.filmdoms.community.board.post.data.dto.request.PostCreateRequestDto;
 import com.filmdoms.community.board.post.service.PostService;
+import com.filmdoms.community.config.TestSecurityConfig;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockPart;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(
-        controllers = PostController.class,
-        excludeAutoConfiguration = SecurityAutoConfiguration.class,
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+@WebMvcTest(PostController.class)
+@Import(TestSecurityConfig.class)
 @DisplayName("컨트롤러 - 게시글 서비스")
 class PostControllerTest {
 
+    @Autowired
+    private ObjectMapper mapper;
     @Autowired
     private MockMvc mockMvc;
     @MockBean
     private PostService postService;
 
     @Test
+    @WithAnonymousUser
     @DisplayName("메인 페이지에서 게시글 조회시, 최근 게시글 4개를 반환한다.")
     void givenNothing_whenViewingPostsFromMainPage_thenReturnsFourRecentPosts() throws Exception {
 
@@ -54,11 +63,6 @@ class PostControllerTest {
                 .andExpect(jsonPath("$[?(@.result.length() == 3)]").doesNotExist());
     }
 
-    @Test
-    @DisplayName("메인 페이지에서 게시글 조회시, 최근 게시글 4개를 반환한다.")
-    void givenCreatingPostRequest_whenCreatingPost_thenReturnsCreatedPostId() throws Exception {
-    }
-
     public List<PostBriefDto> getMockPostBriefDtos() {
         return List.of(
                 PostBriefDto.builder().title("title1").postCategory(PostCategory.FREE).commentCount(5).build(),
@@ -66,6 +70,53 @@ class PostControllerTest {
                 PostBriefDto.builder().title("title3").postCategory(PostCategory.REVIEW).commentCount(15).build(),
                 PostBriefDto.builder().title("title4").postCategory(PostCategory.FREE).commentCount(20).build()
         );
+    }
+
+    @Test
+    @WithUserDetails(value = "testUser", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("게시글 생성 요청시, 정상적인 요청이라면, 생성된 게시글 ID를 반환한다.")
+    void givenCreatingPostRequest_whenCreatingPost_thenReturnsCreatedPostId() throws Exception {
+        // Given
+        PostCreateRequestDto requestDto = PostCreateRequestDto.builder()
+                .category(PostCategory.FREE)
+                .title("title")
+                .content("content")
+                .build();
+        PostBriefDto dto = PostBriefDto.builder().id(1L).build();
+        given(postService.create(any(), any(), any(), any())).willReturn(dto);
+
+        // When & Then
+        mockMvc.perform(multipart("/api/v1/post/create")
+                        .part(new MockPart("data", mapper.writeValueAsBytes(requestDto)))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
+                .andExpect(jsonPath("$..result[?(@..id)]").exists());
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("게시글 생성 요청시, 로그인 하지 않으면, 인증 에러를 반환한다.")
+    void givenUnauthencicatedUser_whenCreatingPost_thenReturnsUserNotFoundErrorCode() throws Exception {
+        // Given
+        PostCreateRequestDto requestDto = PostCreateRequestDto.builder()
+                .category(PostCategory.FREE)
+                .title("title")
+                .content("content")
+                .build();
+
+        // When & Then
+        mockMvc.perform(multipart("/api/v1/post/create")
+                        .part(new MockPart("data", mapper.writeValueAsBytes(requestDto)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.result == null)]").exists())
+                .andExpect(jsonPath("$[?(@.resultCode == 'AUTHENTICATION_ERROR')]").exists());
+        then(postService).shouldHaveNoInteractions();
     }
 
 }

--- a/src/test/java/com/filmdoms/community/board/post/service/PostServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/post/service/PostServiceTest.java
@@ -1,20 +1,25 @@
 package com.filmdoms.community.board.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.filmdoms.community.account.config.SecurityConfig;
 import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.post.data.constants.PostCategory;
+import com.filmdoms.community.board.post.data.dto.PostAccountDto;
 import com.filmdoms.community.board.post.data.dto.PostBriefDto;
+import com.filmdoms.community.board.post.data.dto.request.PostCreateRequestDto;
 import com.filmdoms.community.board.post.data.entity.PostHeader;
 import com.filmdoms.community.board.post.repository.PostHeaderRepository;
-import com.filmdoms.community.board.post.service.PostService;
 import com.filmdoms.community.imagefile.service.ImageFileService;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +41,9 @@ class PostServiceTest {
     PostService postService;
 
     @MockBean
-    PostHeaderRepository postHeaderRepository;
-    @MockBean
     AccountRepository accountRepository;
+    @MockBean
+    PostHeaderRepository postHeaderRepository;
     @MockBean
     ImageFileService imageFileService;
 
@@ -46,7 +51,7 @@ class PostServiceTest {
     @DisplayName("최근 게시글 조회를 요청하면, 최근 게시글을 4개 반환한다.")
     void givenNothing_whenSearchingRecentPosts_thenReturnsRecentPosts() {
         // Given
-        given(postHeaderRepository.findFirst4ByOrderByIdDesc()).willReturn(getMockPosts());
+        given(postHeaderRepository.findFirst4ByOrderByIdDesc()).willReturn(getMockPosts(getMockAccount()));
 
         // When
         List<PostBriefDto> postBriefDtos = postService.getMainPagePosts();
@@ -56,34 +61,53 @@ class PostServiceTest {
         assertThat(postBriefDtos.size()).isEqualTo(4);
     }
 
+    @Test
+    @DisplayName("게시글 저장을 요청하면, 게시글 정보를 반환한다.")
+    void givenPostInfo_whenSavingPost_thenSavesPostInfo() {
+        // Given
+        Account mockAccount = getMockAccount();
+        AccountDto mockAccountDto = AccountDto.from(mockAccount);
+        PostCreateRequestDto mockRequestDto = PostCreateRequestDto.builder()
+                .category(PostCategory.FREE)
+                .title("title")
+                .content("content")
+                .build();
+        given(postHeaderRepository.save(any())).willReturn(getMockPost(mockAccount, mockRequestDto));
 
-    public List<PostHeader> getMockPosts() {
-        Account testAccount = Account.of(1L, "tester", "testpw", AccountRole.USER);
-        return List.of(
-                PostHeader.builder()
-                        .author(testAccount)
-                        .category(PostCategory.FREE)
-                        .title("test post4")
-                        .content(BoardContent.builder().content("This is a test post.").build())
-                        .build(),
-                PostHeader.builder()
-                        .author(testAccount)
-                        .category(PostCategory.FREE)
-                        .title("test post3")
-                        .content(BoardContent.builder().content("This is a test post.").build())
-                        .build(),
-                PostHeader.builder()
-                        .author(testAccount)
-                        .category(PostCategory.FREE)
-                        .title("test post2")
-                        .content(BoardContent.builder().content("This is a test post.").build())
-                        .build(),
-                PostHeader.builder()
-                        .author(testAccount)
-                        .category(PostCategory.FREE)
-                        .title("test post1")
-                        .content(BoardContent.builder().content("This is a test post.").build())
-                        .build()
-        );
+        // When
+        PostBriefDto postBriefDto = postService.create(mockAccountDto, mockRequestDto, null, null);
+
+        // Then
+        assertThat(postBriefDto)
+                .hasFieldOrPropertyWithValue("title", mockRequestDto.getTitle())
+                .hasFieldOrPropertyWithValue("author", PostAccountDto.from(mockAccount))
+                .hasFieldOrPropertyWithValue("postCategory", mockRequestDto.getCategory());
     }
+
+    public Account getMockAccount() {
+        return Account.of(1L, "tester", "testpw", AccountRole.USER);
+    }
+
+    public List<PostHeader> getMockPosts(Account author) {
+        return IntStream.range(1, 5)
+                .mapToObj(number -> {
+                    return PostHeader.builder()
+                            .author(author)
+                            .category(PostCategory.FREE)
+                            .title("test post" + Integer.toString(number))
+                            .content(BoardContent.builder().content("This is a test post.").build())
+                            .build();
+                })
+                .toList();
+    }
+
+    public PostHeader getMockPost(Account author, PostCreateRequestDto requestDto) {
+        return PostHeader.builder()
+                .author(author)
+                .category(requestDto.getCategory())
+                .title(requestDto.getTitle())
+                .content(BoardContent.builder().content(requestDto.getContent()).build())
+                .build();
+    }
+
 }

--- a/src/test/java/com/filmdoms/community/board/review/repository/MovieReviewHeaderRepositoryTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/repository/MovieReviewHeaderRepositoryTest.java
@@ -12,8 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
 class MovieReviewHeaderRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
@@ -29,9 +29,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @DisplayName("영화 리뷰 서비스-리포지토리 통합 테스트")
 class MovieReviewServiceTest {
 

--- a/src/test/java/com/filmdoms/community/config/TestSecurityConfig.java
+++ b/src/test/java/com/filmdoms/community/config/TestSecurityConfig.java
@@ -1,0 +1,40 @@
+package com.filmdoms.community.config;
+
+import static org.mockito.BDDMockito.given;
+
+import com.filmdoms.community.account.config.SecurityConfig;
+import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.service.UserDetailsServiceImpl;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+@Import({SecurityConfig.class, JwtTokenProvider.class, UserDetailsServiceImpl.class})
+@TestPropertySource(properties = {
+        "JWT_KEY=aKeyThatIsVeryLongToBeUsedForJWTKEY"
+})
+public class TestSecurityConfig {
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    UserDetailsService userDetailsService;
+    @MockBean
+    private AccountRepository accountRepository;
+
+    @BeforeTestMethod
+    public void securitySetUp() {
+        given(accountRepository.findByUsername("testUser")).willReturn(
+                Optional.of(Account.of(1L, "testUser", "password", AccountRole.USER)));
+        given(accountRepository.findByUsername("testAdmin")).willReturn(
+                Optional.of(Account.of(2L, "testAdmin", "password", AccountRole.ADMIN)));
+    }
+
+}


### PR DESCRIPTION
주요 변경사항은 다음과 같습니다.

* **중요: 요청 데이터 검증을 위해 Spring Validation 의존성을 추가했습니다.** 관련 구현 기능은 첫 번째 커밋을 참조 바랍니다.
* 게시글 추가 기능을 구현했고, 그에 대한 테스트 코드를 작성했습니다.
* data.sql 때문에 생기던 테스트 오류를 잡아내고, 수정했습니다.

이번 PR 이후로 통합테스트 코드 작성시, 클래스에 다음과 같이 `@ActiveProfiles("test")` 어노테이션을 붙여 sql 초기 데이터 생성 오류를 방지해 주시기 바랍니다.
```java
@DataJpaTest
@ActiveProfiles("test")
@DisplayName("공지 서비스-리포지토리 통합 테스트")
class NoticeServiceTest {
```