### PR TITLE
테스트 버그 수정

### DIFF
--- a/src/test/java/com/filmdoms/community/annotation/DataJpaTestWithJPAAuditing.java
+++ b/src/test/java/com/filmdoms/community/annotation/DataJpaTestWithJPAAuditing.java
@@ -1,0 +1,22 @@
+package com.filmdoms.community.annotation;
+
+import com.filmdoms.community.account.config.JpaConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("test")
+@DataJpaTest(includeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = {JpaConfig.class}
+))
+public @interface DataJpaTestWithJPAAuditing {
+}

--- a/src/test/java/com/filmdoms/community/annotation/DataJpaTestWithJpaAuditing.java
+++ b/src/test/java/com/filmdoms/community/annotation/DataJpaTestWithJpaAuditing.java
@@ -18,5 +18,5 @@ import java.lang.annotation.Target;
         type = FilterType.ASSIGNABLE_TYPE,
         classes = {JpaConfig.class}
 ))
-public @interface DataJpaTestWithJPAAuditing {
+public @interface DataJpaTestWithJpaAuditing {
 }

--- a/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
@@ -1,14 +1,10 @@
 package com.filmdoms.community.board.notice.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.annotation.DataJpaTestWithJPAAuditing;
 import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestDto;
 import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
 import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
@@ -18,24 +14,27 @@ import com.filmdoms.community.imagefile.service.AmazonS3UploadService;
 import com.filmdoms.community.imagefile.service.ImageFileService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
-@DataJpaTest
-@ActiveProfiles("test")
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+@DataJpaTestWithJPAAuditing
 @DisplayName("공지 서비스-리포지토리 통합 테스트")
 class NoticeServiceTest {
 

--- a/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
@@ -4,7 +4,7 @@ import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.repository.AccountRepository;
-import com.filmdoms.community.annotation.DataJpaTestWithJPAAuditing;
+import com.filmdoms.community.annotation.DataJpaTestWithJpaAuditing;
 import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestDto;
 import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
 import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
-@DataJpaTestWithJPAAuditing
+@DataJpaTestWithJpaAuditing
 @DisplayName("공지 서비스-리포지토리 통합 테스트")
 class NoticeServiceTest {
 

--- a/src/test/java/com/filmdoms/community/board/review/repository/MovieReviewHeaderRepositoryTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/repository/MovieReviewHeaderRepositoryTest.java
@@ -3,7 +3,7 @@ package com.filmdoms.community.board.review.repository;
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
-import com.filmdoms.community.annotation.DataJpaTestWithJPAAuditing;
+import com.filmdoms.community.annotation.DataJpaTestWithJpaAuditing;
 import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.data.constant.MovieReviewTag;
 import com.filmdoms.community.board.review.data.entity.MovieReviewHeader;
@@ -12,9 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
-import org.springframework.test.context.ActiveProfiles;
 
-@DataJpaTestWithJPAAuditing
+@DataJpaTestWithJpaAuditing
 class MovieReviewHeaderRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/filmdoms/community/board/review/repository/MovieReviewHeaderRepositoryTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/repository/MovieReviewHeaderRepositoryTest.java
@@ -3,19 +3,18 @@ package com.filmdoms.community.board.review.repository;
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.annotation.DataJpaTestWithJPAAuditing;
 import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.data.constant.MovieReviewTag;
 import com.filmdoms.community.board.review.data.entity.MovieReviewHeader;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
 import org.springframework.test.context.ActiveProfiles;
 
-@DataJpaTest
-@ActiveProfiles("test")
+@DataJpaTestWithJPAAuditing
 class MovieReviewHeaderRepositoryTest {
 
     @Autowired
@@ -27,6 +26,7 @@ class MovieReviewHeaderRepositoryTest {
     @Test
     void 생성일_내림차순으로_상위_5개_반환() throws InterruptedException {
 
+        //given
         Account author = Account.of("user1", "1234", AccountRole.USER);
         accountRepository.save(author);
 
@@ -41,7 +41,10 @@ class MovieReviewHeaderRepositoryTest {
             Thread.sleep(10);
         }
 
+        //when
         List<MovieReviewHeader> result = movieReviewHeaderRepository.findTop5ByOrderByDateCreatedDesc();
+
+        //then
         for (int i = 0; i < 5; i++) {
             Assertions.assertThat(result.get(i).getTitle())
                     .endsWith(String.valueOf(9 - i));

--- a/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
@@ -3,7 +3,7 @@ package com.filmdoms.community.board.review.service;
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
-import com.filmdoms.community.annotation.DataJpaTestWithJPAAuditing;
+import com.filmdoms.community.annotation.DataJpaTestWithJpaAuditing;
 import com.filmdoms.community.board.data.constant.MovieReviewTag;
 import com.filmdoms.community.board.review.data.dto.request.MovieReviewCreateRequestDto;
 import com.filmdoms.community.board.review.data.dto.response.MovieReviewCreateResponseDto;
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
-@DataJpaTestWithJPAAuditing
+@DataJpaTestWithJpaAuditing
 @DisplayName("영화 리뷰 서비스-리포지토리 통합 테스트")
 class MovieReviewServiceTest {
 

--- a/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/review/service/MovieReviewServiceTest.java
@@ -1,12 +1,9 @@
 package com.filmdoms.community.board.review.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.annotation.DataJpaTestWithJPAAuditing;
 import com.filmdoms.community.board.data.constant.MovieReviewTag;
 import com.filmdoms.community.board.review.data.dto.request.MovieReviewCreateRequestDto;
 import com.filmdoms.community.board.review.data.dto.response.MovieReviewCreateResponseDto;
@@ -17,23 +14,25 @@ import com.filmdoms.community.imagefile.service.AmazonS3UploadService;
 import com.filmdoms.community.imagefile.service.ImageFileService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
-@DataJpaTest
-@ActiveProfiles("test")
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+@DataJpaTestWithJPAAuditing
 @DisplayName("영화 리뷰 서비스-리포지토리 통합 테스트")
 class MovieReviewServiceTest {
 


### PR DESCRIPTION
* Jpa Auditing 관련 설정이 적용되지 않아 테스트 케이스가 실패하던 오류를 해결했습니다.
* DataJpaTestWithJpaAuditing 어노테이션을 만들었습니다. 설명은 해당 커밋 참조하시면 됩니다.