### PR TITLE
게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/login", "/join").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/**").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/**").authenticated()
                         .anyRequest().permitAll())
 
                 // H2 DB 사용을 위해, x-frame-options 동일 출처 허용

--- a/src/main/java/com/filmdoms/community/board/post/controller/PostController.java
+++ b/src/main/java/com/filmdoms/community/board/post/controller/PostController.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,7 +43,7 @@ public class PostController {
     }
 
     @PostMapping
-    public Response<PostCreateResponseDto> create(
+    public Response<PostCreateResponseDto> createPost(
             @AuthenticationPrincipal AccountDto accountDto,
             @RequestBody @Valid PostCreateRequestDto requestDto) {
         return Response.success(PostCreateResponseDto.from(
@@ -56,5 +57,13 @@ public class PostController {
             @PathVariable Long postId,
             @RequestBody @Valid PostUpdateRequestDto requestDto) {
         return Response.success(PostUpdateResponseDto.from(postService.update(accountDto, postId, requestDto)));
+    }
+
+    @DeleteMapping("/{postId}")
+    public Response deletePost(
+            @AuthenticationPrincipal AccountDto accountDto,
+            @PathVariable Long postId) {
+        postService.delete(accountDto, postId);
+        return Response.success();
     }
 }

--- a/src/main/java/com/filmdoms/community/board/post/repository/PostHeaderRepository.java
+++ b/src/main/java/com/filmdoms/community/board/post/repository/PostHeaderRepository.java
@@ -2,6 +2,7 @@ package com.filmdoms.community.board.post.repository;
 
 import com.filmdoms.community.board.post.data.entity.PostHeader;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,4 +18,10 @@ public interface PostHeaderRepository extends JpaRepository<PostHeader, Long> {
             + "JOIN FETCH header.boardContent.imageFiles "
             + "WHERE header.id = :headerId")
     PostHeader findByIdWithAuthorContentImage(Long headerId);
+
+    @Query("SELECT distinct header "
+            + "FROM PostHeader header "
+            + "JOIN FETCH header.author "
+            + "WHERE header.id = :headerId")
+    Optional<PostHeader> findByIdWithAuthor(Long headerId);
 }

--- a/src/main/java/com/filmdoms/community/board/post/service/PostService.java
+++ b/src/main/java/com/filmdoms/community/board/post/service/PostService.java
@@ -82,7 +82,6 @@ public class PostService {
         PostHeader savedHeader = postHeaderRepository.save(updatedHeader);
         log.info("게시글 반환 타입으로 변환");
         return PostBriefDto.from(savedHeader);
-
     }
 
     private PostHeader updateHeader(PostHeader header, PostUpdateRequestDto requestDto) {
@@ -110,5 +109,16 @@ public class PostService {
                 .peek(imageFile -> log.info("추가할 이미지 ID: {}", imageFile.getId()))
                 .forEach(imageFile -> imageFile.updateBoardContent(content));
         return header;
+    }
+
+    public void delete(AccountDto accountDto, Long postHeaderId) {
+        PostHeader header = postHeaderRepository.findByIdWithAuthor(postHeaderId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.URI_NOT_FOUND));
+        log.info("작성자 확인");
+        if (!AccountDto.from(header.getAuthor()).equals(accountDto)) {
+            throw new ApplicationException(ErrorCode.INVALID_PERMISSION, "게시글의 작성자와 일치하지 않습니다.");
+        }
+        log.info("게시글 삭제");
+        postHeaderRepository.delete(header);
     }
 }


### PR DESCRIPTION
게시글 삭제 기능을 구현했습니다.
/api/v1/post/{postId} 로 JWT와 함께 삭제 요청을 보내면, 게시글 헤더, 콘텐츠, 댓글, 이미지까지 연관된 모든 데이터가 삭제됩니다.
게시글 삭제시엔 작성자만 확인하므로, 리포지토리에 작성자만 패치 조인으로 불러오는 메서드를 추가했습니다.

다음 경우에 대한 테스트 코드를 작성했습니다.
* 게시글 삭제 요청시, 정상적인 요청이라면, 성공 코드를 반환한다.
* 게시글 삭제 요청시, 로그인 안된 유저라면, 인증 에러를 반환한다.
* 게시글 삭제 요청시, 생성자와 다른 유저라면, 권한 에러를 반환한다.
* 게시글 삭제 요청시, 존재하지 않는 게시글이라면, 에러를 반환한다. 