### PR TITLE
공지 RUD 기능 생성

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/dto/response/PostDetailAuthorResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/PostDetailAuthorResponseDto.java
@@ -1,0 +1,16 @@
+package com.filmdoms.community.account.data.dto.response;
+
+import com.filmdoms.community.account.data.entity.Account;
+import lombok.Getter;
+
+@Getter
+public class PostDetailAuthorResponseDto { //게시물 상세 조회 시 작성자 정보를 주는 DTO
+
+    private Long id;
+    private String username;
+
+    public PostDetailAuthorResponseDto(Account account) {
+        this.id = account.getId();
+        this.username = account.getUsername();
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
     INVALID_IMAGE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 이미지 아이디입니다."),
     NO_IMAGE_ERROR(HttpStatus.BAD_REQUEST, "이미지가 전달되지 않았습니다."),
     EMPTY_FILE_ERROR(HttpStatus.BAD_REQUEST, "비어 있는 파일입니다."),
-    IMAGE_BELONG_TO_OTHER_POST(HttpStatus.BAD_REQUEST, "다른 게시물에 포함된 이미지입니다.")
+    IMAGE_BELONG_TO_OTHER_POST(HttpStatus.BAD_REQUEST, "다른 게시물에 포함된 이미지입니다."),
+    INVALID_POST_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물 아이디입니다."),
+    MAIN_IMAGE_ID_NOT_IN_CONTENT_IMAGE_ID_LIST(HttpStatus.BAD_REQUEST, "메인 이미지 ID는 전체 이미지 ID 리스트에 포함되어야 합니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/filmdoms/community/board/data/BoardContent.java
+++ b/src/main/java/com/filmdoms/community/board/data/BoardContent.java
@@ -25,7 +25,7 @@ public final class BoardContent {
     @Column(name = "content", nullable = false, length = 10000)
     private String content;
 
-    @OneToMany(mappedBy = "boardContent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "boardContent", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final Set<ImageFile> imageFiles = new HashSet<>();
 
     @Builder

--- a/src/main/java/com/filmdoms/community/board/data/dto/BoardHeadCoreDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/data/dto/BoardHeadCoreDetailResponseDto.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
-public class BoardHeadCoreDetailResponseDto {
+public abstract class BoardHeadCoreDetailResponseDto {
     private Long id;
     private String title;
     private PostDetailAuthorResponseDto author;

--- a/src/main/java/com/filmdoms/community/board/data/dto/BoardHeadCoreDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/data/dto/BoardHeadCoreDetailResponseDto.java
@@ -1,0 +1,33 @@
+package com.filmdoms.community.board.data.dto;
+
+import com.filmdoms.community.account.data.dto.response.PostDetailAuthorResponseDto;
+import com.filmdoms.community.board.data.BoardHeadCore;
+import com.filmdoms.community.board.data.constant.PostStatus;
+import com.filmdoms.community.imagefile.data.dto.response.ImageResponseDto;
+import lombok.Getter;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class BoardHeadCoreDetailResponseDto {
+    private Long id;
+    private String title;
+    private PostDetailAuthorResponseDto author;
+    private int view;
+    private PostStatus status;
+    private String content;
+    private Set<ImageResponseDto> image;
+
+    protected BoardHeadCoreDetailResponseDto(BoardHeadCore boardHeadCore) {
+        this.id = boardHeadCore.getId();
+        this.title = boardHeadCore.getTitle();
+        this.author = new PostDetailAuthorResponseDto(boardHeadCore.getAuthor());
+        this.view = boardHeadCore.getView();
+        this.status = boardHeadCore.getStatus();
+        this.content = boardHeadCore.getBoardContent().getContent();
+        this.image = boardHeadCore.getBoardContent().getImageFiles().stream()
+                .map(ImageResponseDto::new)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/controller/NoticeController.java
+++ b/src/main/java/com/filmdoms/community/board/notice/controller/NoticeController.java
@@ -3,15 +3,17 @@ package com.filmdoms.community.board.notice.controller;
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestDto;
+import com.filmdoms.community.board.notice.data.dto.request.NoticeUpdateRequestDto;
 import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
+import com.filmdoms.community.board.notice.data.dto.response.NoticeDetailResponseDto;
 import com.filmdoms.community.board.notice.data.dto.response.NoticeMainPageDto;
+import com.filmdoms.community.board.notice.data.dto.response.NoticeUpdateResponseDto;
 import com.filmdoms.community.board.notice.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.List;
 
 @Slf4j
@@ -31,6 +33,25 @@ public class NoticeController {
     @PostMapping
     public Response<NoticeCreateResponseDto> create(@RequestBody NoticeCreateRequestDto requestDto, @AuthenticationPrincipal AccountDto accountDto) {
         NoticeCreateResponseDto responseDto = noticeService.create(requestDto, accountDto);
+        return Response.success(responseDto);
+    }
+
+    @GetMapping("/{noticeId}")
+    public Response<NoticeDetailResponseDto> detail(@PathVariable Long noticeId) {
+        NoticeDetailResponseDto responseDto = noticeService.getDetail(noticeId);
+        return Response.success(responseDto);
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public Response delete(@PathVariable Long noticeId) {
+        noticeService.deleteNotice(noticeId);
+        return Response.success();
+    }
+
+    @PutMapping("/{noticeId}")
+    public Response<NoticeUpdateResponseDto> update(@PathVariable Long noticeId, @RequestBody NoticeUpdateRequestDto requestDto) {
+        log.info("{}", requestDto.getContentImageId());
+        NoticeUpdateResponseDto responseDto = noticeService.updateNotice(noticeId, requestDto);
         return Response.success(responseDto);
     }
 

--- a/src/main/java/com/filmdoms/community/board/notice/controller/NoticeController.java
+++ b/src/main/java/com/filmdoms/community/board/notice/controller/NoticeController.java
@@ -50,7 +50,6 @@ public class NoticeController {
 
     @PutMapping("/{noticeId}")
     public Response<NoticeUpdateResponseDto> update(@PathVariable Long noticeId, @RequestBody NoticeUpdateRequestDto requestDto) {
-        log.info("{}", requestDto.getContentImageId());
         NoticeUpdateResponseDto responseDto = noticeService.updateNotice(noticeId, requestDto);
         return Response.success(responseDto);
     }

--- a/src/main/java/com/filmdoms/community/board/notice/data/dto/request/NoticeUpdateRequestDto.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/dto/request/NoticeUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.filmdoms.community.board.notice.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@AllArgsConstructor //테스트에 필요
+@NoArgsConstructor
+@Getter
+public class NoticeUpdateRequestDto {
+
+    private String title;
+    private String content;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Long mainImageId;
+    private Set<Long> contentImageId;
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeDetailResponseDto.java
@@ -1,0 +1,22 @@
+package com.filmdoms.community.board.notice.data.dto.response;
+
+import com.filmdoms.community.board.data.dto.BoardHeadCoreDetailResponseDto;
+import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NoticeDetailResponseDto extends BoardHeadCoreDetailResponseDto {
+
+    //메인 페이지 정보는 상세 조회시 필요 없음
+    //comment 구현되면 comment 정보도 같이 넘기기
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    public NoticeDetailResponseDto(NoticeHeader noticeHeader) {
+        super(noticeHeader);
+        this.startDate = noticeHeader.getStartDate();
+        this.endDate = noticeHeader.getEndDate();
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeUpdateResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/dto/response/NoticeUpdateResponseDto.java
@@ -1,0 +1,14 @@
+package com.filmdoms.community.board.notice.data.dto.response;
+
+import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
+import lombok.Getter;
+
+@Getter
+public class NoticeUpdateResponseDto {
+
+    private Long postId;
+
+    public NoticeUpdateResponseDto(NoticeHeader header) {
+        this.postId = header.getId();
+    }
+}

--- a/src/main/java/com/filmdoms/community/board/notice/data/entity/NoticeHeader.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/entity/NoticeHeader.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Getter
 public class NoticeHeader extends BoardHeadCore {
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "image_file_id")
     private ImageFile mainImage;
 
@@ -33,6 +33,15 @@ public class NoticeHeader extends BoardHeadCore {
     private NoticeHeader(String title, Account author, BoardContent boardContent, ImageFile mainImage, LocalDateTime startDate, LocalDateTime endDate) {
         super(title, author, boardContent);
         this.mainImage = mainImage;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void update(String title, String content, ImageFile mainImageFile, LocalDateTime startDate, LocalDateTime endDate) {
+        //업데이트 방법 정해지면 수정
+        updateTitle(title);
+        getBoardContent().updateContent(content);
+        this.mainImage = mainImageFile;
         this.startDate = startDate;
         this.endDate = endDate;
     }

--- a/src/main/java/com/filmdoms/community/imagefile/data/dto/response/ImageResponseDto.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/dto/response/ImageResponseDto.java
@@ -1,0 +1,16 @@
+package com.filmdoms.community.imagefile.data.dto.response;
+
+import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
+import lombok.Getter;
+
+@Getter
+public class ImageResponseDto {
+
+    private Long id;
+    private String uuidFileName;
+
+    public ImageResponseDto(ImageFile imageFile) {
+        this.id = imageFile.getId();
+        this.uuidFileName = imageFile.getUuidFileName();
+    }
+}

--- a/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
@@ -31,7 +31,7 @@ public class ImageFile extends BaseTimeEntity {
     String originalFileName;
     @Column(name = "uuid_file_name")
     String uuidFileName;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_content_id")
     public BoardContent boardContent;
 

--- a/src/main/java/com/filmdoms/community/imagefile/service/ImageFileService.java
+++ b/src/main/java/com/filmdoms/community/imagefile/service/ImageFileService.java
@@ -5,11 +5,14 @@ import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
 import com.filmdoms.community.imagefile.repository.ImageFileRepository;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -36,5 +39,37 @@ public class ImageFileService {
             throw new ApplicationException(ErrorCode.IMAGE_BELONG_TO_OTHER_POST); //이미지에 이미 게시글 컨텐츠가 매핑되어 있으면 예외 발생
         }
         imageFile.updateBoardContent(content);
+    }
+
+    public void updateImageContent(Set<Long> updateImageIds, BoardContent boardContent) {
+        if (updateImageIds == null) {
+            return;
+        }
+        Set<ImageFile> updateImageFiles;
+
+        //업데이트할 ImageFile 엔티티들을 불러오고, 유효하지 않은 이미지 ID라면 예외를 발생시킴
+        try {
+            updateImageFiles = updateImageIds.stream()
+                    .map(id -> imageFileRepository.findById(id).get())
+                    .collect(Collectors.toSet());
+        } catch (NoSuchElementException e) {
+            throw new ApplicationException(ErrorCode.INVALID_IMAGE_ID);
+        }
+
+        //원래 가지고 있던 이미지 중 업데이트 목록에 없는 것들은 삭제
+        Set<ImageFile> originalImageFiles = boardContent.getImageFiles();
+        originalImageFiles.stream()
+                .filter(image -> !updateImageFiles.contains(image))
+                .forEach(image -> imageFileRepository.delete(image));
+
+        //업데이트 목록에 있는 이미지 중 원래 목록에 없는 것들은 헤더 설정
+        updateImageFiles.stream()
+                .filter(image -> !originalImageFiles.contains(image))
+                .forEach(image -> {
+                    if(image.getBoardContent() != null) {
+                        throw new ApplicationException(ErrorCode.IMAGE_BELONG_TO_OTHER_POST);
+                    }
+                    image.updateBoardContent(boardContent);
+                });
     }
 }

--- a/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/filmdoms/community/board/notice/service/NoticeServiceTest.java
@@ -1,8 +1,5 @@
 package com.filmdoms.community.board.notice.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.entity.Account;
@@ -14,23 +11,24 @@ import com.filmdoms.community.board.notice.data.dto.request.NoticeCreateRequestD
 import com.filmdoms.community.board.notice.data.dto.response.NoticeCreateResponseDto;
 import com.filmdoms.community.board.notice.data.entity.NoticeHeader;
 import com.filmdoms.community.board.notice.repository.NoticeHeaderRepository;
-import com.filmdoms.community.imagefile.data.dto.UploadedFileDto;
 import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
 import com.filmdoms.community.imagefile.repository.ImageFileRepository;
 import com.filmdoms.community.imagefile.service.AmazonS3UploadService;
 import com.filmdoms.community.imagefile.service.ImageFileService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTestWithJpaAuditing
 @DisplayName("공지 서비스-리포지토리 통합 테스트")
@@ -115,6 +113,7 @@ class NoticeServiceTest {
         assertThat(header.getBoardContent().getImageFiles().size()).isEqualTo(contentImageId.size()); //메인이미지 개수 + 서브이미지 개수
         assertThat(header.getTitle()).isEqualTo(requestDto.getTitle()); //request DTO에서 전달된 값들이 저장되었는지 확인
         assertThat(header.getAuthor().getId()).isEqualTo(testUser.getId());
+        assertThat(header.getMainImage().getId()).isEqualTo(mainImageId);
         assertThat(header.getBoardContent().getContent()).isEqualTo(requestDto.getContent());
         assertThat(header.getStartDate()).isEqualTo(requestDto.getStartDate());
         assertThat(header.getEndDate()).isEqualTo(requestDto.getEndDate());


### PR DESCRIPTION
공지글 RUD 기능을 생성했습니다.
스프링 시큐리티 설정에서 공지 CUD 부분은 따로 어드민 계정만 접근 가능하도록 권한을 설정해주면 돼서 인증 로직은 넣지 않았습니다.

RUD는 각각
`GET /api/v1/notice/{공지 ID}`
`POST /api/v1/notice/{공지 ID}`
`DELETE /api/v1/notice/{공지 ID}`
로 호출 가능합니다.

* 공지 상세조회 호출에 대한 json 응답 예시
```json
{
    "resultCode": "SUCCESS",
    "result": {
        "id": 21,
        "title": "Sed ante.",
        "author": {
            "id": 28,
            "username": "bshermorer"
        },
        "view": 57,
        "status": "INACTIVE",
        "content": "Integer a nibh. In quis justo. Maecenas rhoncus aliquam lacus.",
        "image": [
            {
                "id": 21,
                "uuidFileName": "3554e88f-d683-4f18-b3f4-33fbf6905792.webp"
            }
        ],
        "startDate": "2022-05-02T07:09:01",
        "endDate": "2022-09-21T10:27:27"
    }
}
```

* 수정 요청 json 예시
```json
{
    "title" : "수정 타이틀",
    "content" : "수정 내용",
    "startDate" : "2023-03-11T00:00:00",
    "endDate" : "2023-04-12T00:00:00",
    "mainImageId" : "41",
    "contentImageId" : ["41", "42"]
}
```

* 아직 댓글을 구현하지 않아서 조회 기능은 미완성이고, 쿼리 최적화도 필요합니다.
