### PR TITLE
헤더와 컨텐츠 업데이트 메서드 작성

### DIFF
--- a/src/main/java/com/filmdoms/community/board/data/BoardContent.java
+++ b/src/main/java/com/filmdoms/community/board/data/BoardContent.java
@@ -38,7 +38,7 @@ public final class BoardContent {
         this.content = content;
     }
 
-    public void updateContent(String content) {
+    void updateBoardContent(String content) {
         this.content = content;
     }
 }

--- a/src/main/java/com/filmdoms/community/board/data/BoardHeadCore.java
+++ b/src/main/java/com/filmdoms/community/board/data/BoardHeadCore.java
@@ -2,7 +2,22 @@ package com.filmdoms.community.board.data;
 
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.board.data.constant.PostStatus;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,7 +56,8 @@ public class BoardHeadCore extends BaseTimeEntity {
         this.boardContent = boardContent;
     }
 
-    public void updateTitle(String title) {
+    protected void updateBoardHeadCore(String title, String content) {
         this.title = title;
+        this.boardContent.updateBoardContent(content);
     }
 }


### PR DESCRIPTION
회의 결과, 각 게시글 업데이트는 각 엔티티 마다 업데이트 할 필드를 모두 받아 한번에 업데이트 하는 메서드를 만들기로 했습니다.

이에 코어 엔티티를 업데이트 하는 메서드를 작성해야 할 필요가 생겼고, 따라서 헤더는 protected 로, 컨텐츠는 default 메서드로 각각 업데이트 메서드를 작성했다.

## **참고 사항**

각각의 헤더에서 update 메서드 작성시 아래와 같이 `updateBoardHeadCore` 를 호출해 제목과 본문을 수정할 수 있도록 해주세요.
```
    public void update(String title, ImageFile mainImage) {
        updateBoardHeadCore(title, null);
        this.mainImage = mainImage;
    }
```