### PR TITLE
이미지 엔티티 내부에 URL 생성 메서드 작성

### DIFF
--- a/src/main/java/com/filmdoms/community/board/banner/data/entity/BannerHeader.java
+++ b/src/main/java/com/filmdoms/community/board/banner/data/entity/BannerHeader.java
@@ -38,11 +38,11 @@ public class BannerHeader extends BoardHeadCore {
         this.mainImage = mainImage;
     }
 
-    public String getFirstImageUrl(String domain) {
-        return ImageFileDto.from(mainImage, domain).getFileUrl();
+    public void update(String title, ImageFile mainImage) {
+        updateBoardHeadCore(title, null);
     }
 
-    public void updateMainImage(ImageFile mainImage) {
-        this.mainImage = mainImage;
+    public String getMainImageUrl(String domain) {
+        return mainImage.getFileUrl(domain);
     }
 }

--- a/src/main/java/com/filmdoms/community/imagefile/data/dto/ImageFileDto.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/dto/ImageFileDto.java
@@ -18,12 +18,11 @@ public class ImageFileDto {
     private Long contentId;
 
     public static ImageFileDto from(ImageFile entity, String domain) {
-        String fileUrl = domain + "/" + entity.getUuidFileName();
 
         return ImageFileDto.builder()
                 .id(entity.getId())
                 .uuidFileName(entity.getUuidFileName())
-                .fileUrl(fileUrl)
+                .fileUrl(entity.getFileUrl(domain))
                 .contentId(entity.getBoardContent().getId())
                 .build();
     }

--- a/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
+++ b/src/main/java/com/filmdoms/community/imagefile/data/entitiy/ImageFile.java
@@ -3,7 +3,6 @@ package com.filmdoms.community.imagefile.data.entitiy;
 
 import com.filmdoms.community.board.data.BaseTimeEntity;
 import com.filmdoms.community.board.data.BoardContent;
-import com.filmdoms.community.board.data.BoardHeadCore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -46,6 +45,10 @@ public class ImageFile extends BaseTimeEntity {
 
     public void updateBoardContent(BoardContent boardContent) {
         this.boardContent = boardContent;
+    }
+
+    public String getFileUrl(String domain) {
+        return domain + "/" + uuidFileName;
     }
 
     @Override


### PR DESCRIPTION
```java
public String getFirstImageUrl(String domain) {
        return ImageFileDto.from(mainImage, domain).getFileUrl();
```
기존 방식으로 이미지 엔티티에서 URL을 받으려면, ImageFile 을 ImageFileDto 로 변경 후, getUrl() 메서드를 호출해야 했습니다.
하지만 이 방식은 상위 객체인 엔티티가 하위 객체를 참조하고 있다는 점에서 DIP를 어겼다고 생각했습니다.

```java
public String getMainImageUrl(String domain) {
        return mainImage.getFileUrl(domain);
```
따라서 엔티티에서 domain을 받아 URL을 생성하는 메서드를 작성해주었고, 관련 코드를 수정했습니다.