### PR TITLE
이미지 URL 및 업데이트 메서드 반영하는 리팩토링

### DIFF
--- a/src/main/java/com/filmdoms/community/board/banner/controller/BannerController.java
+++ b/src/main/java/com/filmdoms/community/board/banner/controller/BannerController.java
@@ -43,10 +43,9 @@ public class BannerController {
 
     @PutMapping("/{bannerId}")
     public Response<BannerInfoResponseDto> updateBanner(
-            @AuthenticationPrincipal AccountDto accountDto,
             @PathVariable Long bannerId,
             @RequestBody BannerInfoRequestDto requestDto) {
-        return Response.success(BannerInfoResponseDto.from(bannerService.update(accountDto, bannerId, requestDto)));
+        return Response.success(BannerInfoResponseDto.from(bannerService.update(bannerId, requestDto)));
     }
 
     @DeleteMapping("/{bannerId}")

--- a/src/main/java/com/filmdoms/community/board/banner/data/dto/BannerDto.java
+++ b/src/main/java/com/filmdoms/community/board/banner/data/dto/BannerDto.java
@@ -18,7 +18,7 @@ public class BannerDto {
     public static BannerDto from(BannerHeader entity, String domain) {
         return BannerDto.builder()
                 .id(entity.getId())
-                .imageUrl(entity.getFirstImageUrl(domain))
+                .imageUrl(entity.getMainImageUrl(domain))
                 .title(entity.getTitle())
                 .build();
     }

--- a/src/main/java/com/filmdoms/community/board/banner/data/dto/response/BannerInfoResponseDto.java
+++ b/src/main/java/com/filmdoms/community/board/banner/data/dto/response/BannerInfoResponseDto.java
@@ -12,14 +12,10 @@ import lombok.Getter;
 public class BannerInfoResponseDto {
 
     private Long id;
-    private String imageUrl;
-    private String title;
 
     public static BannerInfoResponseDto from(BannerDto dto) {
         return BannerInfoResponseDto.builder()
                 .id(dto.getId())
-                .imageUrl(dto.getImageUrl())
-                .title(dto.getTitle())
                 .build();
     }
 }

--- a/src/main/java/com/filmdoms/community/board/banner/data/entity/BannerHeader.java
+++ b/src/main/java/com/filmdoms/community/board/banner/data/entity/BannerHeader.java
@@ -3,18 +3,12 @@ package com.filmdoms.community.board.banner.data.entity;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.board.data.BoardContent;
 import com.filmdoms.community.board.data.BoardHeadCore;
-import com.filmdoms.community.imagefile.data.dto.ImageFileDto;
 import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +34,7 @@ public class BannerHeader extends BoardHeadCore {
 
     public void update(String title, ImageFile mainImage) {
         updateBoardHeadCore(title, null);
+        this.mainImage = mainImage;
     }
 
     public String getMainImageUrl(String domain) {

--- a/src/main/java/com/filmdoms/community/board/notice/data/entity/NoticeHeader.java
+++ b/src/main/java/com/filmdoms/community/board/notice/data/entity/NoticeHeader.java
@@ -39,8 +39,7 @@ public class NoticeHeader extends BoardHeadCore {
 
     public void update(String title, String content, ImageFile mainImageFile, LocalDateTime startDate, LocalDateTime endDate) {
         //업데이트 방법 정해지면 수정
-        updateTitle(title);
-        getBoardContent().updateContent(content);
+        updateBoardHeadCore(title, content);
         this.mainImage = mainImageFile;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/com/filmdoms/community/board/post/data/entity/PostHeader.java
+++ b/src/main/java/com/filmdoms/community/board/post/data/entity/PostHeader.java
@@ -53,12 +53,9 @@ public class PostHeader extends BoardHeadCore {
         this.mainImage = mainImage;
     }
 
-    public void updateCategory(PostCategory category) {
+    public void update(PostCategory category, String title, String content, ImageFile mainImage) {
+        updateBoardHeadCore(title, content);
         this.category = category;
-    }
-
-    public void updateMainImage(ImageFile mainImage) {
         this.mainImage = mainImage;
     }
-
 }

--- a/src/main/java/com/filmdoms/community/board/post/repository/PostHeaderRepository.java
+++ b/src/main/java/com/filmdoms/community/board/post/repository/PostHeaderRepository.java
@@ -17,7 +17,7 @@ public interface PostHeaderRepository extends JpaRepository<PostHeader, Long> {
             + "JOIN FETCH header.boardContent "
             + "JOIN FETCH header.boardContent.imageFiles "
             + "WHERE header.id = :headerId")
-    PostHeader findByIdWithAuthorContentImage(Long headerId);
+    Optional<PostHeader> findByIdWithAuthorContentImage(Long headerId);
 
     @Query("SELECT distinct header "
             + "FROM PostHeader header "

--- a/src/main/java/com/filmdoms/community/board/post/service/PostService.java
+++ b/src/main/java/com/filmdoms/community/board/post/service/PostService.java
@@ -13,10 +13,7 @@ import com.filmdoms.community.board.post.repository.PostHeaderRepository;
 import com.filmdoms.community.imagefile.data.entitiy.ImageFile;
 import com.filmdoms.community.imagefile.repository.ImageFileRepository;
 import com.filmdoms.community.imagefile.service.ImageFileService;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,10 +48,11 @@ public class PostService {
     public PostBriefDto create(AccountDto accountDto,
                                PostCreateRequestDto requestDto) {
 
+        log.info("컨텐츠 생성");
         BoardContent content = BoardContent.builder()
                 .content(requestDto.getContent())
                 .build();
-
+        log.info("헤더 생성");
         PostHeader header = postHeaderRepository.save(PostHeader.builder()
                 .category(requestDto.getCategory())
                 .title(requestDto.getTitle())
@@ -62,10 +60,12 @@ public class PostService {
                 .content(content)
                 .mainImage(imageFileRepository.getReferenceById(requestDto.getMainImageId()))
                 .build());
-
+        log.info("이미지 매핑");
         imageFileService.setImageContent(requestDto.getContentImageId(), content);
+        log.info("게시글 저장");
+        PostHeader savedHeader = postHeaderRepository.save(header);
 
-        return PostBriefDto.from(header);
+        return PostBriefDto.from(savedHeader);
     }
 
     @Transactional
@@ -77,44 +77,21 @@ public class PostService {
         if (!AccountDto.from(header.getAuthor()).equals(accountDto)) {
             throw new ApplicationException(ErrorCode.INVALID_PERMISSION, "게시글의 작성자와 일치하지 않습니다.");
         }
+        log.info("메인 이미지 호출");
+        ImageFile mainImageFile = imageFileRepository.findById(requestDto.getMainImageId())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_IMAGE_ID));
         log.info("게시글 업데이트");
-        PostHeader updatedHeader = updateHeader(header, requestDto);
-        log.info("게시글 저장");
-        PostHeader savedHeader = postHeaderRepository.save(updatedHeader);
+        header.update(requestDto.getCategory(), requestDto.getTitle(), requestDto.getContent(), mainImageFile);
+        log.info("이미지 매핑");
+        imageFileService.updateImageContent(requestDto.getContentImageId(), header.getBoardContent());
         log.info("게시글 반환 타입으로 변환");
-        return PostBriefDto.from(savedHeader);
-    }
-
-    private PostHeader updateHeader(PostHeader header, PostUpdateRequestDto requestDto) {
-        BoardContent content = header.getBoardContent();
-        Set<ImageFile> originalImageFiles = content.getImageFiles();
-        List<ImageFile> updatingImageFiles = imageFileRepository.findAllById(requestDto.getContentImageId());
-
-        log.info("카테고리 수정");
-        header.updateCategory(requestDto.getCategory());
-        log.info("메인 이미지 수정");
-        header.updateMainImage(imageFileRepository.getReferenceById(requestDto.getMainImageId()));
-        log.info("제목 수정");
-        header.updateTitle(requestDto.getTitle());
-        log.info("본문 수정");
-        content.updateContent(requestDto.getContent());
-        log.info("없는 이미지 삭제");
-        originalImageFiles.stream()
-                .filter(imageFile -> !updatingImageFiles.contains(imageFile))
-                .collect(Collectors.toSet()).stream() // 새로운 컬렉션으로 만들지 않으면 ConcurrentModificationException 발생
-                .peek(imageFile -> log.info("삭제할 이미지 ID: {}", imageFile.getId()))
-                .forEach(originalImageFiles::remove);
-        log.info("새로 생긴 이미지 추가");
-        updatingImageFiles.stream()
-                .filter(imageFile -> !originalImageFiles.contains(imageFile))
-                .peek(imageFile -> log.info("추가할 이미지 ID: {}", imageFile.getId()))
-                .forEach(imageFile -> imageFile.updateBoardContent(content));
-        return header;
+        return PostBriefDto.from(header);
     }
 
     public void delete(AccountDto accountDto, Long postHeaderId) {
+        log.info("게시글 호출");
         PostHeader header = postHeaderRepository.findByIdWithAuthor(postHeaderId)
-                .orElseThrow(() -> new ApplicationException(ErrorCode.URI_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_POST_ID));
         log.info("작성자 확인");
         if (!AccountDto.from(header.getAuthor()).equals(accountDto)) {
             throw new ApplicationException(ErrorCode.INVALID_PERMISSION, "게시글의 작성자와 일치하지 않습니다.");

--- a/src/main/java/com/filmdoms/community/board/post/service/PostService.java
+++ b/src/main/java/com/filmdoms/community/board/post/service/PostService.java
@@ -71,7 +71,8 @@ public class PostService {
     @Transactional
     public PostBriefDto update(AccountDto accountDto, Long postHeaderId, PostUpdateRequestDto requestDto) {
         log.info("게시글 호출");
-        PostHeader header = postHeaderRepository.findByIdWithAuthorContentImage(postHeaderId);
+        PostHeader header = postHeaderRepository.findByIdWithAuthorContentImage(postHeaderId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_POST_ID));
         log.info("작성자 확인");
         if (!AccountDto.from(header.getAuthor()).equals(accountDto)) {
             throw new ApplicationException(ErrorCode.INVALID_PERMISSION, "게시글의 작성자와 일치하지 않습니다.");

--- a/src/test/java/com/filmdoms/community/board/banner/controller/BannerHeaderControllerTest.java
+++ b/src/test/java/com/filmdoms/community/board/banner/controller/BannerHeaderControllerTest.java
@@ -61,8 +61,8 @@ class BannerHeaderControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
-                    .andExpect(jsonPath("$..result[?(@..title)]").exists())
-                    .andExpect(jsonPath("$..result[?(@..imageUrl)]").exists());
+                    .andExpect(jsonPath("$..result..title").exists())
+                    .andExpect(jsonPath("$..result..imageUrl").exists());
         }
     }
 
@@ -91,9 +91,7 @@ class BannerHeaderControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
-                    .andExpect(jsonPath("$..result[?(@..id)]").exists())
-                    .andExpect(jsonPath("$..result[?(@..title)]").exists())
-                    .andExpect(jsonPath("$..result[?(@..imageUrl)]").exists());
+                    .andExpect(jsonPath("$..result.id").exists());
         }
 
         @Test
@@ -150,7 +148,7 @@ class BannerHeaderControllerTest {
                     .id(1L)
                     .title("changed title")
                     .imageUrl("imageUrl.png").build();
-            given(bannerService.update(any(), any(), any())).willReturn(dto);
+            given(bannerService.update(any(), any())).willReturn(dto);
 
             // When & Then
             mockMvc.perform(put("/api/v1/banner/1")
@@ -160,9 +158,7 @@ class BannerHeaderControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
-                    .andExpect(jsonPath("$..result[?(@..id)]").exists())
-                    .andExpect(jsonPath("$..result[?(@..title)]").exists())
-                    .andExpect(jsonPath("$..result[?(@..imageUrl)]").exists());
+                    .andExpect(jsonPath("$..result.id").exists());
         }
 
         @Test


### PR DESCRIPTION
noticeHeader 에 업데이트 메서드를 적용해 `updateBoardHeadCore(title, content);` 를 호출하도록 수정한 것 외에,
주로 배너와 게시글 부분만 이미지 URL과 업데이트 메서드 수정사항을 반영해 바뀌었습니다.