### PR TITLE
게시판 엔티티 통합 및 연관 엔티티 리뉴얼

### DIFF
--- a/src/main/java/com/filmdoms/community/article/data/constant/Category.java
+++ b/src/main/java/com/filmdoms/community/article/data/constant/Category.java
@@ -1,0 +1,12 @@
+package com.filmdoms.community.article.data.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Category {
+    MOVIE("영화게시판"), FILM_UNIVERSE("공지게시판"), CRITIC("비평게시판");
+
+    private final String description;
+}

--- a/src/main/java/com/filmdoms/community/article/data/constant/Tag.java
+++ b/src/main/java/com/filmdoms/community/article/data/constant/Tag.java
@@ -1,0 +1,23 @@
+package com.filmdoms.community.article.data.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Tag {
+    MOVIE(Category.MOVIE, "영화"),
+    OTT(Category.MOVIE, "OTT"),
+    DRAMA(Category.MOVIE, "드라마"),
+    EVENT(Category.MOVIE, "이벤트"),
+    GOODS(Category.MOVIE, "굿즈"),
+    OUTSIDE_ACTIVITY(Category.FILM_UNIVERSE, "대외활동"),
+    COMPETITION(Category.FILM_UNIVERSE, "공모전"),
+    CRITIC_ACTOR(Category.CRITIC, "배우비평"),
+    CRITIC_DIRECTOR(Category.CRITIC, "감독비평"),
+    CRITIC_MOVIE(Category.CRITIC, "영화비평");
+
+
+    private final Category category;
+    private final String description;
+}

--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -1,0 +1,57 @@
+package com.filmdoms.community.article.data.entity;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.Tag;
+import com.filmdoms.community.board.data.BaseTimeEntity;
+import com.filmdoms.community.board.data.constant.PostStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Article extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    private Tag tag;
+
+    @JoinColumn(name = "account_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Account author;
+
+    @Enumerated(EnumType.STRING)
+    private PostStatus status = PostStatus.ACTIVE;
+
+    @JoinColumn(name = "content_id")
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Content content;
+
+    private int view = 0;
+
+    private int voteCount = 0;
+
+    private boolean containsImage = false;
+
+    @Builder
+    protected Article(String title, Category category, Tag tag, Account author, String content) {
+        this.title = title;
+        this.category = category;
+        this.tag = tag;
+        this.author = author;
+        this.content = new Content(content);
+    }
+}

--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -47,7 +47,7 @@ public class Article extends BaseTimeEntity {
     private boolean containsImage = false;
 
     @Builder
-    protected Article(String title, Category category, Tag tag, Account author, String content) {
+    private Article(String title, Category category, Tag tag, Account author, String content) {
         this.title = title;
         this.category = category;
         this.tag = tag;

--- a/src/main/java/com/filmdoms/community/article/data/entity/Content.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Content.java
@@ -1,0 +1,30 @@
+package com.filmdoms.community.article.data.entity;
+
+import com.filmdoms.community.file.data.entity.FileContent;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public final class Content {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", length = 10000)
+    private String content;
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.REMOVE)
+    private Set<FileContent> fileContents = new HashSet<>();
+
+    Content(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
@@ -1,0 +1,8 @@
+package com.filmdoms.community.article.repository;
+
+import com.filmdoms.community.article.data.entity.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+}

--- a/src/main/java/com/filmdoms/community/file/data/entity/File.java
+++ b/src/main/java/com/filmdoms/community/file/data/entity/File.java
@@ -1,0 +1,38 @@
+package com.filmdoms.community.file.data.entity;
+
+import com.filmdoms.community.board.data.BaseTimeEntity;
+import com.filmdoms.community.board.data.BoardContent;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class File extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String originalFileName;
+
+    private String uuidFileName;
+
+    @Builder
+    private File(String uuidFileName, String originalFileName, BoardContent boardContent) {
+        this.uuidFileName = uuidFileName;
+        this.originalFileName = originalFileName;
+    }
+
+    public String getFileUrl(String domain) {
+        return domain + "/" + uuidFileName;
+    }
+}

--- a/src/main/java/com/filmdoms/community/file/data/entity/FileContent.java
+++ b/src/main/java/com/filmdoms/community/file/data/entity/FileContent.java
@@ -25,7 +25,7 @@ public class FileContent {
     private Content content;
 
     @Builder
-    public FileContent(File file, Content content) {
+    private FileContent(File file, Content content) {
         this.file = file;
         this.content = content;
     }

--- a/src/main/java/com/filmdoms/community/file/data/entity/FileContent.java
+++ b/src/main/java/com/filmdoms/community/file/data/entity/FileContent.java
@@ -1,0 +1,32 @@
+package com.filmdoms.community.file.data.entity;
+
+import com.filmdoms.community.article.data.entity.Content;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode
+public class FileContent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "file_id")
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE) //File 자동 삭제(cascade) 여부 논의 필요, OneToOne이어야 cascade 옵션 적용 가능
+    private File file;
+
+    @JoinColumn(name = "content_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Content content;
+
+    @Builder
+    public FileContent(File file, Content content) {
+        this.file = file;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/filmdoms/community/file/repository/FileContentRepository.java
+++ b/src/main/java/com/filmdoms/community/file/repository/FileContentRepository.java
@@ -1,0 +1,7 @@
+package com.filmdoms.community.file.repository;
+
+import com.filmdoms.community.file.data.entity.FileContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileContentRepository extends JpaRepository<FileContent, Long> {
+}

--- a/src/main/java/com/filmdoms/community/file/repository/FileRepository.java
+++ b/src/main/java/com/filmdoms/community/file/repository/FileRepository.java
@@ -1,0 +1,7 @@
+package com.filmdoms.community.file.repository;
+
+import com.filmdoms.community.file.data.entity.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
@@ -1,0 +1,55 @@
+package com.filmdoms.community.newcomment.data.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.board.data.BaseTimeEntity;
+import com.filmdoms.community.board.data.BoardHeadCore;
+import com.filmdoms.community.board.data.constant.CommentStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(indexes = {
+        @Index(columnList = "article_id")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class NewComment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "article_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    @JoinColumn(name = "new_comment_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private NewComment parentComment;
+
+    @JoinColumn(name = "account_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Account author;
+
+    @Column(name = "content", nullable = false, length = 1000)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private CommentStatus status = CommentStatus.ACTIVE;
+
+    private boolean isManagerComment = false;
+
+    @Builder
+    public NewComment(Article article, NewComment parentComment, Account author, String content, boolean isManagerComment) {
+        this.article = article;
+        this.parentComment = parentComment;
+        this.author = author;
+        this.content = content;
+        this.isManagerComment = isManagerComment;
+    }
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
@@ -45,7 +45,7 @@ public class NewComment extends BaseTimeEntity {
     private boolean isManagerComment = false;
 
     @Builder
-    public NewComment(Article article, NewComment parentComment, Account author, String content, boolean isManagerComment) {
+    private NewComment(Article article, NewComment parentComment, Account author, String content, boolean isManagerComment) {
         this.article = article;
         this.parentComment = parentComment;
         this.author = author;

--- a/src/main/java/com/filmdoms/community/newcomment/repository/NewCommentRepository.java
+++ b/src/main/java/com/filmdoms/community/newcomment/repository/NewCommentRepository.java
@@ -1,0 +1,7 @@
+package com.filmdoms.community.newcomment.repository;
+
+import com.filmdoms.community.newcomment.data.entity.NewComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewCommentRepository extends JpaRepository<NewComment, Long> {
+}


### PR DESCRIPTION
통합 게시판 엔티티를 만들었고, 그에 따라 연관 엔티티(댓글, 이미지 등)도 다시 새로 작성했습니다.

기존 `ImageFile` 엔티티는 `File` 엔티티로 새로 만들었는데, 추후 이미지가 아닌 다른 파일을 저장할 일을 생각하면 리팩토링 종료 이후에 클래스명을 계속 유지해도 좋을 것 같습니다.

`ImageFile`에 있던 `equals`, `hashcode` 메서드는 `lombok`의 `@EqualsAndHashCode`를 사용해서 `FileContent`로 옮겨놓았습니다.

그 외 언급할 사항들은 커밋 메시지에 적어놓았습니다. 제가 임의로 정한 부분이 꽤 있어서 변경이 필요한 부분은 말씀해주시면 반영해서 수정하도록 하겠습니다!