### PR TITLE
추천 기능 API 개발

### DIFF
--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     EMPTY_FILE_ERROR(HttpStatus.BAD_REQUEST, "비어 있는 파일입니다."),
     IMAGE_BELONG_TO_OTHER_POST(HttpStatus.BAD_REQUEST, "다른 게시물에 포함된 이미지입니다."),
     INVALID_POST_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물 아이디입니다."),
+    INVALID_ARTICLE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물 아이디입니다."),
     MAIN_IMAGE_ID_NOT_IN_CONTENT_IMAGE_ID_LIST(HttpStatus.BAD_REQUEST, "메인 이미지 ID는 전체 이미지 ID 리스트에 포함되어야 합니다."),
     NOT_SOCIAL_LOGIN_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 로그인 계정이 아닙니다.")
     ;

--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -66,4 +66,12 @@ public class Article extends BaseTimeEntity {
                 .tag(dto.getTag())
                 .build();
     }
+
+    public int addVote() {
+        return ++voteCount;
+    }
+
+    public int removeVote() {
+        return --voteCount;
+    }
 }

--- a/src/main/java/com/filmdoms/community/vote/controller/VoteController.java
+++ b/src/main/java/com/filmdoms/community/vote/controller/VoteController.java
@@ -1,0 +1,27 @@
+package com.filmdoms.community.vote.controller;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.vote.data.dto.VoteResponseDto;
+import com.filmdoms.community.vote.service.VoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/article/{articleId}/vote")
+@RequiredArgsConstructor
+public class VoteController {
+
+    private final VoteService voteService;
+
+    @PostMapping()
+    public Response<VoteResponseDto> toggleVote(
+            @PathVariable Long articleId,
+            @AuthenticationPrincipal AccountDto accountDto) {
+        return Response.success(voteService.toggleVote(accountDto, articleId));
+    }
+}

--- a/src/main/java/com/filmdoms/community/vote/data/dto/VoteResponseDto.java
+++ b/src/main/java/com/filmdoms/community/vote/data/dto/VoteResponseDto.java
@@ -1,0 +1,17 @@
+package com.filmdoms.community.vote.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class VoteResponseDto {
+
+    private Boolean isVoted;
+
+    private Integer voteCount;
+}

--- a/src/main/java/com/filmdoms/community/vote/data/entity/Vote.java
+++ b/src/main/java/com/filmdoms/community/vote/data/entity/Vote.java
@@ -1,0 +1,19 @@
+package com.filmdoms.community.vote.data.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Vote {
+
+    @EmbeddedId
+    private VoteKey voteKey;
+
+}

--- a/src/main/java/com/filmdoms/community/vote/data/entity/VoteKey.java
+++ b/src/main/java/com/filmdoms/community/vote/data/entity/VoteKey.java
@@ -1,0 +1,31 @@
+package com.filmdoms.community.vote.data.entity;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.entity.Article;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class VoteKey implements Serializable {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+}

--- a/src/main/java/com/filmdoms/community/vote/repository/VoteRepository.java
+++ b/src/main/java/com/filmdoms/community/vote/repository/VoteRepository.java
@@ -1,0 +1,11 @@
+package com.filmdoms.community.vote.repository;
+
+import com.filmdoms.community.vote.data.entity.Vote;
+import com.filmdoms.community.vote.data.entity.VoteKey;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRepository extends JpaRepository<Vote, VoteKey> {
+
+    Optional<Vote> findByVoteKey(VoteKey voteKey);
+}

--- a/src/main/java/com/filmdoms/community/vote/service/VoteService.java
+++ b/src/main/java/com/filmdoms/community/vote/service/VoteService.java
@@ -1,0 +1,59 @@
+package com.filmdoms.community.vote.service;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.vote.data.dto.VoteResponseDto;
+import com.filmdoms.community.vote.data.entity.Vote;
+import com.filmdoms.community.vote.data.entity.VoteKey;
+import com.filmdoms.community.vote.repository.VoteRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VoteService {
+
+    private final ArticleRepository articleRepository;
+    private final AccountRepository accountRepository;
+    private final VoteRepository voteRepository;
+
+    @Transactional
+    public VoteResponseDto toggleVote(AccountDto accountDto, Long articleId) {
+
+        Account account = accountRepository.getReferenceById(accountDto.getId());
+
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_ARTICLE_ID));
+
+        VoteKey voteKey = VoteKey.builder()
+                .account(account)
+                .article(article)
+                .build();
+
+        Optional<Vote> foundVote = voteRepository.findByVoteKey(voteKey);
+        int voteCount;
+        boolean pressedResult;
+
+        if (foundVote.isPresent()) {
+            voteRepository.delete(foundVote.get());
+            voteCount = article.removeVote();
+            pressedResult = false;
+        } else {
+            voteRepository.save(new Vote(voteKey));
+            voteCount = article.addVote();
+            pressedResult = true;
+        }
+
+        return VoteResponseDto.builder()
+                .voteCount(voteCount)
+                .isVoted(pressedResult)
+                .build();
+    }
+}

--- a/src/test/java/com/filmdoms/community/vote/controller/VoteControllerTest.java
+++ b/src/test/java/com/filmdoms/community/vote/controller/VoteControllerTest.java
@@ -1,0 +1,94 @@
+package com.filmdoms.community.vote.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.config.TestSecurityConfig;
+import com.filmdoms.community.vote.data.dto.VoteResponseDto;
+import com.filmdoms.community.vote.service.VoteService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(VoteController.class)
+@Import(TestSecurityConfig.class)
+@DisplayName("컨트롤러 - 추천 기능")
+class VoteControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private VoteService voteService;
+
+    @Test
+    @WithUserDetails(value = "testUser", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("게시글을 추천 요청시, 정상적인 요청이라면, 게시글의 총 추천 수와 나의 추천 여부를 반환한다.")
+    void givenProperRequest_whenVotingArticle_thenReturnsVoteResult() throws Exception {
+
+        VoteResponseDto responseDto = VoteResponseDto.builder()
+                .isVoted(true)
+                .voteCount(1)
+                .build();
+        // Given
+        given(voteService.toggleVote(any(), any())).willReturn(responseDto);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/article/1/vote"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.resultCode == 'SUCCESS')]").exists())
+                .andExpect(jsonPath("$.result.isVoted").exists())
+                .andExpect(jsonPath("$.result.voteCount").exists());
+    }
+
+    @Test
+    @WithUserDetails(value = "testUser", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("게시글을 추천 요청시, 존재하지 않는 게시글이라면, 에러를 반환한다.")
+    void givenInvalidPostId_whenVotingArticle_thenReturnsUriNotFoundErrorCode() throws Exception {
+
+        // Given
+        doThrow(new ApplicationException(ErrorCode.URI_NOT_FOUND))
+                .when(voteService).toggleVote(any(), any());
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/article/1/vote"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.resultCode == 'URI_NOT_FOUND')]").exists())
+                .andExpect(jsonPath("$[?(@.result == null)]").exists());
+    }
+
+    @Test
+    @WithAnonymousUser()
+    @DisplayName("게시글을 추천 요청시, 미인증 유저라면, 인증 에러를 반환한다.")
+    void givenUnauthenticatedUser_whenVotingArticle_thenReturnsUnauthenticatedErrorCode() throws Exception {
+
+        // Given
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/article/1/vote"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.result == null)]").exists())
+                .andExpect(jsonPath("$[?(@.resultCode == 'AUTHENTICATION_ERROR')]").exists());
+    }
+
+}

--- a/src/test/java/com/filmdoms/community/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/filmdoms/community/vote/service/VoteServiceTest.java
@@ -1,0 +1,126 @@
+package com.filmdoms.community.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.filmdoms.community.account.config.SecurityConfig;
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.board.post.data.dto.PostBriefDto;
+import com.filmdoms.community.vote.data.dto.VoteResponseDto;
+import com.filmdoms.community.vote.data.entity.Vote;
+import com.filmdoms.community.vote.repository.VoteRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@WebMvcTest(
+        controllers = VoteService.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+class VoteServiceTest {
+
+    @Autowired
+    VoteService voteService;
+    @MockBean
+    ArticleRepository articleRepository;
+    @MockBean
+    AccountRepository accountRepository;
+    @MockBean
+    VoteRepository voteRepository;
+
+    @Test
+    @DisplayName("추천 요청이 들어올 때, 이미 추천한 게시글이면, 추천을 삭제한 결과를 반환한다.")
+    void givenAlreadyVotedArticle_whenTogglingArticleVote_thenReturnsDeletedResult() {
+
+        long articleId = 1L;
+        int previousVoteCount = 1;
+        int expectedVoteCount = 0;
+        AccountDto mockAccountDto = mock(AccountDto.class);
+        Account mockAccount = mock(Account.class);
+        Article mockArticle = mock(Article.class);
+        Vote mockVote = mock(Vote.class);
+
+        // Given
+        given(accountRepository.getReferenceById(any())).willReturn(mockAccount);
+        given(articleRepository.findById(any())).willReturn(Optional.of(mockArticle));
+        given(voteRepository.findByVoteKey(any())).willReturn(Optional.of(mockVote));
+        given(mockAccountDto.getId()).willReturn(1L);
+        given(mockArticle.removeVote()).willReturn(previousVoteCount - 1);
+
+        // When
+        VoteResponseDto result = voteService.toggleVote(mockAccountDto, articleId);
+
+        // Then
+        assertThat(result.getVoteCount()).isEqualTo(expectedVoteCount);
+        assertThat(result.getIsVoted()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("추천 요청이 들어올 때, 아직 추천하지 않은 게시글이면, 추천을 추가한 결과를 반환한다.")
+    void givenNotVotedArticle_whenTogglingArticleVote_thenReturnsAddedResult() {
+
+        long articleId = 1L;
+        int previousVoteCount = 1;
+        int expectedVoteCount = 2;
+        AccountDto mockAccountDto = mock(AccountDto.class);
+        Account mockAccount = mock(Account.class);
+        Article mockArticle = mock(Article.class);
+
+        // Given
+        given(accountRepository.getReferenceById(any())).willReturn(mockAccount);
+        given(articleRepository.findById(any())).willReturn(Optional.of(mockArticle));
+        given(voteRepository.findByVoteKey(any())).willReturn(Optional.empty());
+        given(mockAccountDto.getId()).willReturn(1L);
+        given(mockArticle.addVote()).willReturn(previousVoteCount + 1);
+
+        // When
+        VoteResponseDto result = voteService.toggleVote(mockAccountDto, articleId);
+
+        // Then
+        assertThat(result.getVoteCount()).isEqualTo(expectedVoteCount);
+        assertThat(result.getIsVoted()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("추천 요청이 들어올 때, 요청 게시글이 존재하지 않는다면, 예외를 발생시킨다.")
+    void givenInvalidArticleId_whenTogglingArticleVote_thenThrowsException() {
+
+        long articleId = 1L;
+        AccountDto mockAccountDto = mock(AccountDto.class);
+        Account mockAccount = mock(Account.class);
+
+        // Given
+        given(accountRepository.getReferenceById(any())).willReturn(mockAccount);
+        given(articleRepository.findById(any())).willReturn(Optional.empty());
+        given(mockAccountDto.getId()).willReturn(1L);
+
+        // When
+        Throwable throwable = catchThrowable(() ->
+                voteService.toggleVote(mockAccountDto, articleId));
+
+        // Then
+        assertThat(throwable)
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(ErrorCode.INVALID_ARTICLE_ID.getMessage());
+        then(accountRepository).should().getReferenceById(any());
+        then(voteRepository).shouldHaveNoInteractions();
+    }
+}


### PR DESCRIPTION
로그인 된 유저가 `/api/v1/article/{articleId}/vote` 로 Body 없이 요청을 보내면, 해당 게시글에 추천을 더하거나 삭제하는 API 입니다.

* 참고 사항
  * Vote 엔티티에는 Article 과 Account가 VoteKey로 저장되어 있기 때문에, Article 만으로 Vote 개수를 조회할 수 없는 것 같습니다.
  * 때문에 게시글 추천 숫자를 수정할 때, 테이블을 조회하지 않고, 미리 로드된 게시글에 추천 수를 더하거나 빼 반영하도록 구현했습니다. 