### PR TITLE
게시글 상세 API 응답에 로그인 사용자 추천 여부 추가

### DIFF
--- a/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
+++ b/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
@@ -1,5 +1,6 @@
 package com.filmdoms.community.article.controller;
 
+import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.dto.response.detail.ArticleDetailResponseDto;
@@ -9,6 +10,7 @@ import com.filmdoms.community.article.service.ArticleService;
 import com.filmdoms.community.article.service.InitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -35,8 +37,8 @@ public class ArticleController2 {
     }
 
     @GetMapping("/{category}/{articleId}")
-    public Response<ArticleDetailResponseDto> readDetail(@PathVariable Category category, @PathVariable Long articleId) {
-        ArticleDetailResponseDto dto = articleService.getDetail(category, articleId);
+    public Response<ArticleDetailResponseDto> readDetail(@PathVariable Category category, @PathVariable Long articleId, @AuthenticationPrincipal AccountDto accountDto) {
+        ArticleDetailResponseDto dto = articleService.getDetail(category, articleId, accountDto);
         return Response.success(dto);
     }
 

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/detail/ArticleDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/detail/ArticleDetailResponseDto.java
@@ -29,6 +29,7 @@ public class ArticleDetailResponseDto {
     private int view;
     private int vote_count;
     private int commentCount;
+    private boolean isVoted;
     private String content;
     private LocalDateTime dateCreated;
     private LocalDateTime dateLastModified;
@@ -36,7 +37,7 @@ public class ArticleDetailResponseDto {
     private List<FileResponseDto> images;
     private List<ParentNewCommentResponseDto> comments;
 
-    protected ArticleDetailResponseDto(Article article, List<File> images, List<NewComment> comments) {
+    protected ArticleDetailResponseDto(Article article, List<File> images, List<NewComment> comments, boolean isVoted) {
         this.id = article.getId();
         this.category = article.getCategory();
         this.tag = article.getTag();
@@ -45,6 +46,7 @@ public class ArticleDetailResponseDto {
         this.view = article.getView();
         this.vote_count = article.getVoteCount();
         this.commentCount = comments.size();
+        this.isVoted = isVoted;
         this.content = article.getContent().getContent();
         this.dateCreated = article.getDateCreated();
         this.dateLastModified = article.getDateLastModified();
@@ -53,7 +55,7 @@ public class ArticleDetailResponseDto {
         this.comments = ParentNewCommentResponseDto.convert(comments);
     }
 
-    public static ArticleDetailResponseDto from(Article article, List<File> images, List<NewComment> comments) {
-        return new ArticleDetailResponseDto(article, images, comments);
+    public static ArticleDetailResponseDto from(Article article, List<File> images, List<NewComment> comments, boolean isVoted) {
+        return new ArticleDetailResponseDto(article, images, comments, isVoted);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/detail/FilmUniverseDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/detail/FilmUniverseDetailResponseDto.java
@@ -17,13 +17,13 @@ public class FilmUniverseDetailResponseDto extends ArticleDetailResponseDto {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
-    private FilmUniverseDetailResponseDto(FilmUniverse filmUniverse, List<File> images, List<NewComment> comments) {
-        super(filmUniverse.getArticle(), images, comments);
+    private FilmUniverseDetailResponseDto(FilmUniverse filmUniverse, List<File> images, List<NewComment> comments, boolean isVoted) {
+        super(filmUniverse.getArticle(), images, comments, isVoted);
         this.startDate = filmUniverse.getStartDate();
         this.endDate = filmUniverse.getEndDate();
     }
 
-    public static FilmUniverseDetailResponseDto from(FilmUniverse filmUniverse, List<File> images, List<NewComment> comments) {
-        return new FilmUniverseDetailResponseDto(filmUniverse, images, comments);
+    public static FilmUniverseDetailResponseDto from(FilmUniverse filmUniverse, List<File> images, List<NewComment> comments, boolean isVoted) {
+        return new FilmUniverseDetailResponseDto(filmUniverse, images, comments, isVoted);
     }
 }


### PR DESCRIPTION
게시글 상세 API 응답에 로그인 사용자 추천 여부를 추가헸습니다.

응답 json `voted` 키의 값이 추천 여부를 표시하고, 익명 사용자의 경우 항상 `false`, 로그인 사용자의 경우 추천 여부에 따라 `true`/`false`로 나갑니다.

API 명세도 수정 완료했습니다.