### PR TITLE
댓글 조회 API 분리

### DIFF
--- a/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
+++ b/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
@@ -17,32 +17,32 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/article")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class ArticleController2 {
 
     private final ArticleService articleService;
     private final InitService initService;
 
-    @GetMapping("/{category}/main")
+    @GetMapping("/main/{category}")
     public Response<List<? extends ParentMainPageResponseDto>> readMain(@PathVariable Category category, @RequestParam(defaultValue = "5") int limit) {
         List<? extends ParentMainPageResponseDto> dtoList = articleService.getMainPageDtoList(category, limit);
         return Response.success(dtoList);
     }
 
-    @GetMapping("/recent/main")
+    @GetMapping("/main/recent")
     public Response<List<MovieAndRecentMainPageResponseDto>> readMain(@RequestParam(defaultValue = "5") int limit) {
         List<MovieAndRecentMainPageResponseDto> dtoList = articleService.getRecentMainPageDtoList(limit);
         return Response.success(dtoList);
     }
 
-    @GetMapping("/{category}/{articleId}")
+    @GetMapping("/article/{category}/{articleId}")
     public Response<ArticleDetailResponseDto> readDetail(@PathVariable Category category, @PathVariable Long articleId, @AuthenticationPrincipal AccountDto accountDto) {
         ArticleDetailResponseDto dto = articleService.getDetail(category, articleId, accountDto);
         return Response.success(dto);
     }
 
-    @GetMapping("/init-data")
+    @GetMapping("/article/init-data")
     public Response initData(@RequestParam(defaultValue = "10") int limit) {
         initService.makeArticleData(limit);
         return Response.success();

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/detail/ArticleDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/detail/ArticleDetailResponseDto.java
@@ -7,8 +7,6 @@ import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.board.data.constant.PostStatus;
 import com.filmdoms.community.file.data.dto.response.FileResponseDto;
 import com.filmdoms.community.file.data.entity.File;
-import com.filmdoms.community.newcomment.data.dto.response.ParentNewCommentResponseDto;
-import com.filmdoms.community.newcomment.data.entity.NewComment;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -28,16 +26,14 @@ public class ArticleDetailResponseDto {
     private PostStatus status;
     private int view;
     private int vote_count;
-    private int commentCount;
     private boolean isVoted;
     private String content;
     private LocalDateTime dateCreated;
     private LocalDateTime dateLastModified;
     private DetailPageAccountResponseDto author;
     private List<FileResponseDto> images;
-    private List<ParentNewCommentResponseDto> comments;
 
-    protected ArticleDetailResponseDto(Article article, List<File> images, List<NewComment> comments, boolean isVoted) {
+    protected ArticleDetailResponseDto(Article article, List<File> images, boolean isVoted) {
         this.id = article.getId();
         this.category = article.getCategory();
         this.tag = article.getTag();
@@ -45,17 +41,15 @@ public class ArticleDetailResponseDto {
         this.status = article.getStatus();
         this.view = article.getView();
         this.vote_count = article.getVoteCount();
-        this.commentCount = comments.size();
         this.isVoted = isVoted;
         this.content = article.getContent().getContent();
         this.dateCreated = article.getDateCreated();
         this.dateLastModified = article.getDateLastModified();
         this.author = DetailPageAccountResponseDto.from(article.getAuthor());
         this.images = images.stream().sorted(Comparator.comparing(File::getId)).map(FileResponseDto::from).toList(); //id로 정렬한 뒤 DTO 변환
-        this.comments = ParentNewCommentResponseDto.convert(comments);
     }
 
-    public static ArticleDetailResponseDto from(Article article, List<File> images, List<NewComment> comments, boolean isVoted) {
-        return new ArticleDetailResponseDto(article, images, comments, isVoted);
+    public static ArticleDetailResponseDto from(Article article, List<File> images, boolean isVoted) {
+        return new ArticleDetailResponseDto(article, images, isVoted);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/detail/FilmUniverseDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/detail/FilmUniverseDetailResponseDto.java
@@ -2,7 +2,6 @@ package com.filmdoms.community.article.data.dto.response.detail;
 
 import com.filmdoms.community.article.data.entity.extra.FilmUniverse;
 import com.filmdoms.community.file.data.entity.File;
-import com.filmdoms.community.newcomment.data.entity.NewComment;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -17,13 +16,13 @@ public class FilmUniverseDetailResponseDto extends ArticleDetailResponseDto {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
-    private FilmUniverseDetailResponseDto(FilmUniverse filmUniverse, List<File> images, List<NewComment> comments, boolean isVoted) {
-        super(filmUniverse.getArticle(), images, comments, isVoted);
+    private FilmUniverseDetailResponseDto(FilmUniverse filmUniverse, List<File> images, boolean isVoted) {
+        super(filmUniverse.getArticle(), images, isVoted);
         this.startDate = filmUniverse.getStartDate();
         this.endDate = filmUniverse.getEndDate();
     }
 
-    public static FilmUniverseDetailResponseDto from(FilmUniverse filmUniverse, List<File> images, List<NewComment> comments, boolean isVoted) {
-        return new FilmUniverseDetailResponseDto(filmUniverse, images, comments, isVoted);
+    public static FilmUniverseDetailResponseDto from(FilmUniverse filmUniverse, List<File> images, boolean isVoted) {
+        return new FilmUniverseDetailResponseDto(filmUniverse, images, isVoted);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -23,7 +23,6 @@ import com.filmdoms.community.article.repository.FilmUniverseRepository;
 import com.filmdoms.community.file.data.entity.File;
 import com.filmdoms.community.file.repository.FileRepository;
 import com.filmdoms.community.imagefile.service.ImageFileService;
-import com.filmdoms.community.newcomment.data.entity.NewComment;
 import com.filmdoms.community.newcomment.repository.NewCommentRepository;
 import com.filmdoms.community.vote.data.entity.VoteKey;
 import com.filmdoms.community.vote.repository.VoteRepository;
@@ -115,19 +114,17 @@ public class ArticleService {
             }
 
             List<File> images = fileRepository.findByArticleId(articleId);
-            List<NewComment> comments = newCommentRepository.findByArticleIdWithAuthorProfileImage(articleId);
             boolean isVoted = getArticleVoteStatus(accountDto, article);
 
-            return ArticleDetailResponseDto.from(article, images, comments, isVoted);
+            return ArticleDetailResponseDto.from(article, images, isVoted);
 
         } else if (category == Category.FILM_UNIVERSE) { //총 3번의 쿼리가 나감
             FilmUniverse notice = filmUniverseRepository.findByArticleIdWithArticleAuthorProfileImageContent(articleId).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_ARTICLE_ID));
 
             List<File> images = fileRepository.findByArticleId(articleId);
-            List<NewComment> comments = newCommentRepository.findByArticleIdWithAuthorProfileImage(articleId);
             boolean isVoted = getArticleVoteStatus(accountDto, notice.getArticle());
 
-            return FilmUniverseDetailResponseDto.from(notice, images, comments, isVoted);
+            return FilmUniverseDetailResponseDto.from(notice, images, isVoted);
         }
 
         throw new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND);

--- a/src/main/java/com/filmdoms/community/newcomment/controller/NewCommentController.java
+++ b/src/main/java/com/filmdoms/community/newcomment/controller/NewCommentController.java
@@ -1,0 +1,24 @@
+package com.filmdoms.community.newcomment.controller;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.newcomment.data.dto.response.DetailPageCommentResponseDto;
+import com.filmdoms.community.newcomment.service.NewCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class NewCommentController {
+
+    private final NewCommentService newCommentService;
+
+    @GetMapping("/article/{category}/{articleId}/comments")
+    public Response<DetailPageCommentResponseDto> readArticleComments(@PathVariable Long articleId, @PathVariable Category category) {
+        DetailPageCommentResponseDto dto = newCommentService.getDetailPageCommentList(articleId);
+        return Response.success(dto);
+    }
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/dto/response/DetailPageCommentResponseDto.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/dto/response/DetailPageCommentResponseDto.java
@@ -1,0 +1,23 @@
+package com.filmdoms.community.newcomment.data.dto.response;
+
+import com.filmdoms.community.newcomment.data.entity.NewComment;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DetailPageCommentResponseDto {
+
+    private int commentCount;
+
+    private List<ParentNewCommentResponseDto> comments;
+
+    private DetailPageCommentResponseDto(List<NewComment> comments) {
+        this.commentCount = comments.size();
+        this.comments = ParentNewCommentResponseDto.convert(comments);
+    }
+
+    public static DetailPageCommentResponseDto from(List<NewComment> comments) {
+        return new DetailPageCommentResponseDto(comments);
+    }
+}

--- a/src/main/java/com/filmdoms/community/newcomment/service/NewCommentService.java
+++ b/src/main/java/com/filmdoms/community/newcomment/service/NewCommentService.java
@@ -1,0 +1,27 @@
+package com.filmdoms.community.newcomment.service;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.board.data.constant.CommentStatus;
+import com.filmdoms.community.newcomment.data.dto.response.DetailPageCommentResponseDto;
+import com.filmdoms.community.newcomment.data.entity.NewComment;
+import com.filmdoms.community.newcomment.repository.NewCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NewCommentService {
+
+    private final NewCommentRepository newCommentRepository;
+
+    public DetailPageCommentResponseDto getDetailPageCommentList(Long articleId) {
+        List<NewComment> comments = newCommentRepository.findByArticleIdWithAuthorProfileImage(articleId);
+        return DetailPageCommentResponseDto.from(comments);
+    }
+}


### PR DESCRIPTION
* 게시글 조회 API로부터 댓글 조회 API를 분리했고, 메인 페이지 조회 API 경로를 슬랙에서 논의한 방향으로 수정했습니다.
* API 명세서에 수정사항 반영해 놓았습니다.
* 댓글 조회 API 경로는 `게시글 조회 경로 + /comments`로 설정했는데, 게시글 조회 경로 내 카테고리 정보는 사용하지 않고 있습니다.