### PR TITLE
댓글 CUD 기능 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "존재하지 않는 페이지 입니다."),
     INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 코멘트 아이디입니다."),
     COMMENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "비활성화되었거나 삭제된 코멘트입니다."),
-
+    INVALID_PARENT_COMMENT_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 부모 댓글 아이디이거나, 게시물에 해당 부모 댓글이 존재하지 않습니다."),
+    MANAGER_COMMENT_CANNOT_BE_CREATED(HttpStatus.BAD_REQUEST, "관리자 댓글을 생성할 수 없습니다."),
     MAIN_IMAGE_ID_NOT_IN_CONTENT_IMAGE_ID_LIST(HttpStatus.BAD_REQUEST, "메인 이미지 ID는 전체 이미지 ID 리스트에 포함되어야 합니다."),
     NOT_SOCIAL_LOGIN_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 로그인 계정이 아닙니다.")
     ;

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -7,6 +7,7 @@ import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.file.data.entity.File;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -49,12 +50,17 @@ public class AccountService {
     public AccountDto join(String username, String password) {
         String testUsername = (username == null) ? "tester" : username;
         String testPassword = (password == null) ? "password" : password;
+        File profileImage = File.builder()
+                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                .originalFileName("original_file_name")
+                .build();
+
         Account testAccount = Account.builder()
                 .username(testUsername)
                 .password(passwordEncoder.encode(testPassword))
                 .role(AccountRole.USER)
+                .profileImage(profileImage)
                 .build();
         return AccountDto.from(accountRepository.save(testAccount));
     }
-
 }

--- a/src/main/java/com/filmdoms/community/newcomment/controller/NewCommentController.java
+++ b/src/main/java/com/filmdoms/community/newcomment/controller/NewCommentController.java
@@ -3,7 +3,10 @@ package com.filmdoms.community.newcomment.controller;
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.newcomment.data.dto.request.NewCommentCreateRequestDto;
+import com.filmdoms.community.newcomment.data.dto.request.NewCommentUpdateRequestDto;
 import com.filmdoms.community.newcomment.data.dto.response.DetailPageCommentResponseDto;
+import com.filmdoms.community.newcomment.data.dto.response.NewCommentCreateResponseDto;
 import com.filmdoms.community.newcomment.service.NewCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,9 +19,27 @@ public class NewCommentController {
 
     private final NewCommentService newCommentService;
 
-    @GetMapping("/article/{category}/{articleId}/comments")
-    public Response<DetailPageCommentResponseDto> readArticleComments(@PathVariable Long articleId, @PathVariable Category category) {
+    @GetMapping("/article/{category}/{articleId}/comment")
+    public Response<DetailPageCommentResponseDto> read(@PathVariable Category category, @PathVariable Long articleId) {
         DetailPageCommentResponseDto dto = newCommentService.getDetailPageCommentList(articleId);
         return Response.success(dto);
+    }
+
+    @PostMapping("/comment")
+    public Response<NewCommentCreateResponseDto> create(@RequestBody NewCommentCreateRequestDto requestDto, @AuthenticationPrincipal AccountDto accountDto) {
+        NewCommentCreateResponseDto responseDto = newCommentService.createComment(requestDto, accountDto);
+        return Response.success(responseDto);
+    }
+
+    @PutMapping("/comment/{commentId}")
+    public Response update(@RequestBody NewCommentUpdateRequestDto requestDto, @PathVariable Long commentId, @AuthenticationPrincipal AccountDto accountDto) {
+        newCommentService.updateComment(requestDto, commentId, accountDto);
+        return Response.success();
+    }
+
+    @DeleteMapping("/comment/{commentId}")
+    public Response delete(@PathVariable Long commentId, @AuthenticationPrincipal AccountDto accountDto) {
+        newCommentService.deleteComment(commentId, accountDto);
+        return Response.success();
     }
 }

--- a/src/main/java/com/filmdoms/community/newcomment/data/dto/request/NewCommentCreateRequestDto.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/dto/request/NewCommentCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.filmdoms.community.newcomment.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class NewCommentCreateRequestDto {
+
+    private Long articleId;
+
+    private Long parentCommentId;
+
+    private String content;
+
+    private boolean isManagerComment;
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/dto/request/NewCommentUpdateRequestDto.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/dto/request/NewCommentUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.filmdoms.community.newcomment.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class NewCommentUpdateRequestDto {
+
+    private String content;
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/dto/response/NewCommentCreateResponseDto.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/dto/response/NewCommentCreateResponseDto.java
@@ -1,0 +1,19 @@
+package com.filmdoms.community.newcomment.data.dto.response;
+
+import com.filmdoms.community.newcomment.data.entity.NewComment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class NewCommentCreateResponseDto {
+
+    private Long commentId;
+
+    private NewCommentCreateResponseDto(NewComment comment) {
+        this.commentId = comment.getId();
+    }
+
+    public static NewCommentCreateResponseDto from(NewComment comment) {
+        return new NewCommentCreateResponseDto(comment);
+    }
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
@@ -54,4 +54,12 @@ public class NewComment extends BaseTimeEntity {
         this.content = content;
         this.isManagerComment = isManagerComment;
     }
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public void updateStatus(CommentStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
@@ -1,10 +1,8 @@
 package com.filmdoms.community.newcomment.data.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.board.data.BaseTimeEntity;
-import com.filmdoms.community.board.data.BoardHeadCore;
 import com.filmdoms.community.board.data.constant.CommentStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -59,7 +57,7 @@ public class NewComment extends BaseTimeEntity {
         this.content = content;
     }
 
-    public void updateStatus(CommentStatus status) {
-        this.status = status;
+    public void changeStatusToDeleted() {
+        this.status = CommentStatus.DELETED;
     }
 }

--- a/src/main/java/com/filmdoms/community/newcomment/repository/NewCommentRepository.java
+++ b/src/main/java/com/filmdoms/community/newcomment/repository/NewCommentRepository.java
@@ -13,4 +13,6 @@ public interface NewCommentRepository extends JpaRepository<NewComment, Long> {
             "LEFT JOIN FETCH c.author.profileImage " +
             "WHERE c.article.id = :articleId")
     List<NewComment> findByArticleIdWithAuthorProfileImage(@Param("articleId") Long articleId);
+
+    boolean existsByParentComment(NewComment parentComment);
 }

--- a/src/main/java/com/filmdoms/community/newcomment/service/NewCommentService.java
+++ b/src/main/java/com/filmdoms/community/newcomment/service/NewCommentService.java
@@ -1,27 +1,125 @@
 package com.filmdoms.community.newcomment.service;
 
 import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.repository.ArticleRepository;
 import com.filmdoms.community.board.data.constant.CommentStatus;
+import com.filmdoms.community.newcomment.data.dto.request.NewCommentCreateRequestDto;
+import com.filmdoms.community.newcomment.data.dto.request.NewCommentUpdateRequestDto;
 import com.filmdoms.community.newcomment.data.dto.response.DetailPageCommentResponseDto;
+import com.filmdoms.community.newcomment.data.dto.response.NewCommentCreateResponseDto;
 import com.filmdoms.community.newcomment.data.entity.NewComment;
 import com.filmdoms.community.newcomment.repository.NewCommentRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class NewCommentService {
 
-    private final NewCommentRepository newCommentRepository;
+    private final NewCommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+    private final AccountRepository accountRepository;
 
     public DetailPageCommentResponseDto getDetailPageCommentList(Long articleId) {
-        List<NewComment> comments = newCommentRepository.findByArticleIdWithAuthorProfileImage(articleId);
+        List<NewComment> comments = commentRepository.findByArticleIdWithAuthorProfileImage(articleId);
         return DetailPageCommentResponseDto.from(comments);
+    }
+
+    public NewCommentCreateResponseDto createComment(NewCommentCreateRequestDto requestDto, AccountDto accountDto) {
+        Article article = articleRepository.findById(requestDto.getArticleId()).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_ARTICLE_ID));
+
+        Account author = accountRepository.getReferenceById(accountDto.getId());
+
+        NewComment parentComment = null;
+        if (requestDto.getParentCommentId() != null) {
+            parentComment = commentRepository.findById(requestDto.getParentCommentId()).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_PARENT_COMMENT_ID));
+
+            //위에서 조회한 Article 엔티티가 부모 댓글에 매핑된 Article 엔티티와 동일한지 확인
+            if (!Objects.equals(parentComment.getArticle().getId(), article.getId())) {
+                throw new ApplicationException(ErrorCode.INVALID_PARENT_COMMENT_ID);
+            }
+
+            //부모 댓글이 INACTIVE, DELETED인 경우 댓글 생성 불가능하게 할지 결정 필요
+        }
+
+        //일단 관리자 댓글은 공지 게시판에서 공지 작성자에 의해서만 생성되도록 함
+        if (requestDto.isManagerComment()) {
+            if (article.getCategory() != Category.FILM_UNIVERSE || !Objects.equals(article.getAuthor().getId(), accountDto.getId())) {
+                throw new ApplicationException(ErrorCode.MANAGER_COMMENT_CANNOT_BE_CREATED);
+            }
+        }
+
+        NewComment comment = NewComment.builder()
+                .article(article)
+                .parentComment(parentComment)
+                .author(author)
+                .content(requestDto.getContent())
+                .isManagerComment(requestDto.isManagerComment())
+                .build();
+
+        NewComment savedComment = commentRepository.save(comment);
+        return NewCommentCreateResponseDto.from(savedComment);
+    }
+
+    public void updateComment(NewCommentUpdateRequestDto requestDto, Long commentId, AccountDto accountDto) {
+        NewComment comment = commentRepository.findById(commentId).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
+
+        //ACTIVE 상태인 댓글만 수정 가능
+        checkCommentStatus(comment);
+
+        //수정 권한 확인
+        checkPermission(accountDto, comment);
+
+        comment.update(requestDto.getContent());
+    }
+
+    public void deleteComment(Long commentId, AccountDto accountDto) {
+        NewComment comment = commentRepository.findById(commentId).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
+
+        //ACTIVE 상태인 댓글만 삭제 가능
+        checkCommentStatus(comment);
+
+        //삭제 권한 확인
+        checkPermission(accountDto, comment);
+
+        //자식 댓글의 경우 별도 확인 없이 삭제
+        if (comment.getParentComment() != null) {
+            commentRepository.delete(comment);
+            return;
+        } //DELETED 상태인 부모 댓글의 하나뿐인 자식 댓글이 삭제된 경우 추가 처리를 해줄지 결정 필요
+
+        //부모 댓글의 경우
+        if (commentRepository.existsByParentComment(comment)) {
+            //자식 댓글이 있으면 DELETED로 변경
+            comment.updateStatus(CommentStatus.DELETED);
+        } else {
+            //자식 댓글이 없으면 삭제
+            commentRepository.delete(comment);
+        }
+    }
+
+    private void checkPermission(AccountDto accountDto, NewComment comment) {
+        if (!Objects.equals(comment.getAuthor().getId(), accountDto.getId())) {
+            throw new ApplicationException(ErrorCode.INVALID_PERMISSION);
+        }
+    }
+
+    private void checkCommentStatus(NewComment comment) {
+        if (comment.getStatus() != CommentStatus.ACTIVE) {
+            throw new ApplicationException(ErrorCode.COMMENT_NOT_ACTIVE);
+        }
     }
 }

--- a/src/test/java/com/filmdoms/community/newcomment/service/NewCommentServiceTest.java
+++ b/src/test/java/com/filmdoms/community/newcomment/service/NewCommentServiceTest.java
@@ -1,0 +1,150 @@
+package com.filmdoms.community.newcomment.service;
+
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.annotation.DataJpaTestWithJpaAuditing;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.Tag;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.newcomment.data.dto.request.NewCommentCreateRequestDto;
+import com.filmdoms.community.newcomment.data.dto.request.NewCommentUpdateRequestDto;
+import com.filmdoms.community.newcomment.data.dto.response.NewCommentCreateResponseDto;
+import com.filmdoms.community.newcomment.data.entity.NewComment;
+import com.filmdoms.community.newcomment.repository.NewCommentRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTestWithJpaAuditing
+@DisplayName("댓글 서비스 통합 테스트")
+class NewCommentServiceTest {
+
+    @SpyBean
+    NewCommentService commentService;
+
+    @Autowired
+    NewCommentRepository commentRepository;
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    ArticleRepository articleRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    @DisplayName("부모 댓글 생성이 정상적으로 이루어지는지 확인")
+    void createParentComment() {
+        //given
+        Account articleAuthor = createSampleAccount("articleAuthor");
+        Article article = createSampleArticle(articleAuthor);
+        Account commentAuthor = createSampleAccount("commentAuthor");
+        NewCommentCreateRequestDto requestDto = new NewCommentCreateRequestDto(article.getId(), null, "content", false);
+
+        //when
+        NewCommentCreateResponseDto responseDto = commentService.createComment(requestDto, AccountDto.from(commentAuthor));
+
+        //then
+        NewComment comment = commentRepository.findById(responseDto.getCommentId()).get();
+        assertThat(comment.getArticle().getId()).isEqualTo(requestDto.getArticleId());
+        assertThat(comment.getParentComment()).isNull();
+        assertThat(comment.getContent()).isEqualTo(requestDto.getContent());
+        assertThat(comment.isManagerComment()).isEqualTo(requestDto.isManagerComment());
+    }
+
+    @Test
+    @DisplayName("자식 댓글 생성이 정상적으로 이루어지는지 확인")
+    void createChildComment() {
+        //given
+        Account articleAuthor = createSampleAccount("articleAuthor");
+        Article article = createSampleArticle(articleAuthor);
+        Account parentCommentAuthor = createSampleAccount("parentCommentAuthor");
+        Account childCommentAuthor = createSampleAccount("childCommentAuthor");
+        NewComment parentComment = createSampleComment(article, parentCommentAuthor, null);
+        NewCommentCreateRequestDto requestDto = new NewCommentCreateRequestDto(article.getId(), parentComment.getId(), "content", false);
+
+        //when
+        NewCommentCreateResponseDto responseDto = commentService.createComment(requestDto, AccountDto.from(childCommentAuthor));
+
+        //then
+        NewComment comment = commentRepository.findById(responseDto.getCommentId()).get();
+        assertThat(comment.getArticle().getId()).isEqualTo(requestDto.getArticleId());
+        assertThat(comment.getParentComment().getId()).isEqualTo(requestDto.getParentCommentId());
+        assertThat(comment.getContent()).isEqualTo(requestDto.getContent());
+        assertThat(comment.isManagerComment()).isEqualTo(requestDto.isManagerComment());
+    }
+
+    @Test
+    @DisplayName("댓글 수정이 정상적으로 이루어지는지 확인")
+    void updateComment() {
+        Account articleAuthor = createSampleAccount("articleAuthor");
+        Article article = createSampleArticle(articleAuthor);
+        Account commentAuthor = createSampleAccount("commentAuthor");
+        NewComment comment = createSampleComment(article, commentAuthor, null);
+        NewCommentUpdateRequestDto requestDto = new NewCommentUpdateRequestDto("updatedContent");
+
+        //when
+        commentService.updateComment(requestDto, comment.getId(), AccountDto.from(commentAuthor));
+
+        //then
+        NewComment findComment = commentRepository.findById(comment.getId()).get();
+        assertThat(findComment.getContent()).isEqualTo(requestDto.getContent());
+    }
+
+    @Test
+    @DisplayName("자식 댓글이 없는 부모 댓글 삭제가 정상적으로 이루어지는지 확인")
+    void deleteComment() {
+        Account articleAuthor = createSampleAccount("articleAuthor");
+        Article article = createSampleArticle(articleAuthor);
+        Account commentAuthor = createSampleAccount("commentAuthor");
+        NewComment comment = createSampleComment(article, commentAuthor, null);
+
+        //when
+        commentService.deleteComment(comment.getId(), AccountDto.from(commentAuthor));
+
+        //then
+        assertThat(commentRepository.findById(comment.getId()).isEmpty());
+    }
+
+    private Account createSampleAccount(String username) {
+        Account account = Account.builder()
+                .username(username)
+                .build();
+        return accountRepository.save(account);
+    }
+
+    private Article createSampleArticle(Account author) {
+        Article article = Article.builder()
+                .title("title")
+                .category(Category.MOVIE)
+                .tag(Tag.MOVIE)
+                .content("content")
+                .author(author)
+                .build();
+        return articleRepository.save(article);
+    }
+
+    private NewComment createSampleComment(Article article, Account author, NewComment parentComment) {
+        NewComment comment = NewComment.builder()
+                .article(article)
+                .author(author)
+                .parentComment(parentComment)
+                .isManagerComment(false)
+                .content("content")
+                .build();
+        return commentRepository.save(comment);
+    }
+}


### PR DESCRIPTION
댓글 CUD 기능을 구현했고, API 명세서 업데이트 완료했습니다.

댓글 관련해서 정해진 바가 없어서 임의로 정해서 만든 부분이 여럿 있습니다.

가장 크게 정해야 할 부분은 다음과 같습니다.

1. 부모 댓글이 삭제된 경우, 자식 댓글도 cascade로 삭제 or 부모 댓글 상태는 DELETED로 변경하고 자식 댓글을 삭제하지 않음
2. 공지 게시판의 모든 태그 게시글에 대해 관리자 댓글을 달 수 있는지
3. 관리자를 정하는 방법

3번의 경우, 어떻게 정하느냐에 따라 엔티티 설계가 바뀔 것 같습니다. 일단 2가지 방법이 떠오르는데요.

관리자가 아닌 회원이 공지를 올리고자 할 때,
[1] 공지 내용을 모종의 방법으로 관리자에게 전달하면, 관리자가 확인 후 직접 게시하고, 관리자 페이지에서 관리자를 지정
[2] 회원이 공지를 직접 생성 후 제출하면, 관리자 페이지에서 승인 후 회원 계정으로 게시, 게시글 작성자를 관리자로 지정

방법 [1]은 관리자를 여럿 지정할 수 있고, 방법 [2]는 구현이 상대적으로 간단할 것 같습니다.

아니면 관리자 댓글 기능 구현을 일단 미루는 방법도 있습니다!