### PR TITLE
회원 관련 기능 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -62,10 +62,11 @@ public class AccountController {
     }
 
     @PutMapping("/profile")
-    public Response<AccountResponseDto> updateProfile(
+    public Response<Void> updateProfile(
             @RequestBody UpdateProfileRequestDto requestDto,
             @AuthenticationPrincipal AccountDto accountDto) {
-        return Response.success(accountService.updateAccountProfile(requestDto, accountDto));
+        accountService.updateAccountProfile(requestDto, accountDto);
+        return Response.success();
     }
 
     @PutMapping("/profile/password")

--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -1,21 +1,29 @@
 package com.filmdoms.community.account.controller;
 
 import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
+import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
 import com.filmdoms.community.account.data.dto.request.LoginRequestDto;
+import com.filmdoms.community.account.data.dto.request.UpdatePasswordRequestDto;
+import com.filmdoms.community.account.data.dto.request.UpdateProfileRequestDto;
+import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
 import com.filmdoms.community.account.data.dto.response.CheckDuplicateResponseDto;
 import com.filmdoms.community.account.data.dto.response.LoginResponseDto;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.account.service.AccountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/")
+@RequestMapping("/api/v1/account")
 @RequiredArgsConstructor
 public class AccountController {
 
@@ -32,15 +40,47 @@ public class AccountController {
         return Response.success(new LoginResponseDto(accessToken));
     }
 
-    @GetMapping("/join/duplicate")
+    @PostMapping()
+    public Response<Void> join(@RequestBody JoinRequestDto requestDto) {
+        accountService.createAccount(requestDto);
+        return Response.success();
+    }
+
+    @GetMapping("/check/username")
     public Response<CheckDuplicateResponseDto> isUsernameDuplicate(@RequestParam String username) {
         return Response.success(new CheckDuplicateResponseDto(accountService.isUsernameDuplicate(username)));
     }
 
-    // TODO: 회원 가입 기능 컨트롤러 작성
-    @PostMapping("/join")
-    public Response<?> join() {
-        AccountDto accountDto = accountService.join("testUsername", "testPassword");
+    @GetMapping("/check/email")
+    public Response<CheckDuplicateResponseDto> isEmailDuplicate(@RequestParam String email) {
+        return Response.success(new CheckDuplicateResponseDto(accountService.isEmailDuplicate(email)));
+    }
+
+    @GetMapping("/profile")
+    public Response<AccountResponseDto> viewProfile(@AuthenticationPrincipal AccountDto accountDto) {
+        return Response.success(accountService.readAccount(accountDto));
+    }
+
+    @PutMapping("/profile")
+    public Response<AccountResponseDto> updateProfile(
+            @RequestBody UpdateProfileRequestDto requestDto,
+            @AuthenticationPrincipal AccountDto accountDto) {
+        return Response.success(accountService.updateAccountProfile(requestDto, accountDto));
+    }
+
+    @PutMapping("/profile/password")
+    public Response<Void> updatePassword(
+            @RequestBody UpdatePasswordRequestDto requestDto,
+            @AuthenticationPrincipal AccountDto accountDto) {
+        accountService.updateAccountPassword(requestDto, accountDto);
+        return Response.success();
+    }
+
+    @DeleteMapping()
+    public Response<Void> deleteAccount(
+            @RequestBody DeleteAccountRequestDto requestDto,
+            @AuthenticationPrincipal AccountDto accountDto) {
+        accountService.deleteAccount(requestDto, accountDto);
         return Response.success();
     }
 

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/DeleteAccountRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/DeleteAccountRequestDto.java
@@ -1,0 +1,14 @@
+package com.filmdoms.community.account.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class DeleteAccountRequestDto {
+    private String password;
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/JoinRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/JoinRequestDto.java
@@ -1,0 +1,35 @@
+package com.filmdoms.community.account.data.dto.request;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_EMAIL;
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_NICKNAME;
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_PASSWORD;
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_USERNAME;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class JoinRequestDto {
+
+    @Pattern(regexp = "/^[a-z0-9_]{8,20}$/", message = UNMATCHED_USERNAME)
+    private String username;
+
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,100}", message = UNMATCHED_PASSWORD)
+    private String password;
+
+    @Email(message = UNMATCHED_EMAIL)
+    private String email;
+
+    @Min(value = 2, message = UNMATCHED_NICKNAME)
+    @Max(value = 20, message = UNMATCHED_NICKNAME)
+    private String nickname;
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/UpdatePasswordRequestDto.java
@@ -1,0 +1,20 @@
+package com.filmdoms.community.account.data.dto.request;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_PASSWORD;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class UpdatePasswordRequestDto {
+    private String oldPassword;
+
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,100}", message = UNMATCHED_PASSWORD)
+    private String newPassword;
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/UpdateProfileRequestDto.java
@@ -1,0 +1,26 @@
+package com.filmdoms.community.account.data.dto.request;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.IMAGE_REQUIRED;
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_NICKNAME;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class UpdateProfileRequestDto {
+
+    @NotNull(message = IMAGE_REQUIRED)
+    private Long fileId;
+
+    @Min(value = 2, message = UNMATCHED_NICKNAME)
+    @Max(value = 20, message = UNMATCHED_NICKNAME)
+    private String nickname;
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/AccountResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/AccountResponseDto.java
@@ -1,0 +1,38 @@
+package com.filmdoms.community.account.data.dto.response;
+
+import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.constants.AccountStatus;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.file.data.dto.response.FileResponseDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AccountResponseDto {
+
+    private Long id;
+    private String username;
+    private String nickname;
+    private String email;
+    private AccountRole accountRole;
+    private AccountStatus accountStatus;
+    private boolean isSocialLogin;
+    private FileResponseDto profileImage;
+
+    public static AccountResponseDto from(Account entity) {
+        return AccountResponseDto.builder()
+                .id(entity.getId())
+                .username(entity.getUsername())
+                .nickname(entity.getNickname())
+                .email(entity.getEmail())
+                .accountRole(entity.getAccountRole())
+                .accountStatus(entity.getAccountStatus())
+                .isSocialLogin(entity.isSocialLogin())
+                .profileImage(FileResponseDto.from(entity.getProfileImage()))
+                .build();
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -6,9 +6,6 @@ import com.filmdoms.community.board.data.BaseTimeEntity;
 import com.filmdoms.community.file.data.entity.File;
 import jakarta.persistence.*;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -50,9 +47,6 @@ public class Account extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus = AccountStatus.ACTIVE;
 
-    @Column(name = "date_created")
-    private LocalDateTime dateCreated;
-
     @Column(name = "login_fail_count")
     private int loginFailCount = 0;
 
@@ -74,6 +68,15 @@ public class Account extends BaseTimeEntity {
         this.email = email;
         this.accountRole = Optional.ofNullable(role).orElse(AccountRole.USER);
         this.isSocialLogin = isSocialLogin;
+        this.profileImage = profileImage;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void updateProfile(String nickname, File profileImage) {
+        this.nickname = nickname;
         this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     COMMENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "비활성화되었거나 삭제된 코멘트입니다."),
     INVALID_PARENT_COMMENT_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 부모 댓글 아이디이거나, 게시물에 해당 부모 댓글이 존재하지 않습니다."),
     MANAGER_COMMENT_CANNOT_BE_CREATED(HttpStatus.BAD_REQUEST, "관리자 댓글을 생성할 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "중복된 회원 ID 입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "중복된 회원 이메일 입니다."),
+
     MAIN_IMAGE_ID_NOT_IN_CONTENT_IMAGE_ID_LIST(HttpStatus.BAD_REQUEST, "메인 이미지 ID는 전체 이미지 ID 리스트에 포함되어야 합니다."),
     NOT_SOCIAL_LOGIN_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 로그인 계정이 아닙니다.")
     ;

--- a/src/main/java/com/filmdoms/community/account/exception/ValidationMessage.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ValidationMessage.java
@@ -7,5 +7,9 @@ public class ValidationMessage {
     public static final String CONTENT_NOT_BLANK = "본문은 공백일 수 없습니다.";
     public static final String CONTENT_SIZE = "본문은 10000자 이내이어야 합니다.";
     public static final String IMAGE_REQUIRED = "이미지는 필수로 첨부해주어야 합니다.";
+    public static final String UNMATCHED_USERNAME = "아이디는 8자 이상, 20자 이하의 소문자, 숫자 혹은 \"_\" 의 조합이어야 합니다.";
+    public static final String UNMATCHED_PASSWORD = "비밀번호는 8자 이상, 100자 이하의 대문자, 소문자, 숫자, 및 특수문자의 조합이어야 합니다.";
+    public static final String UNMATCHED_EMAIL = "형식에 맞는 이메일 주소여야 합니다.";
+    public static final String UNMATCHED_NICKNAME = "닉네임은 2자 이상, 20자 이하이어야 합니다.";
 
 }

--- a/src/main/java/com/filmdoms/community/account/repository/AccountRepository.java
+++ b/src/main/java/com/filmdoms/community/account/repository/AccountRepository.java
@@ -3,11 +3,21 @@ package com.filmdoms.community.account.repository;
 import com.filmdoms.community.account.data.entity.Account;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
     Optional<Account> findByUsername(String username);
+
     Optional<Account> findByEmail(String email);
 
     boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+
+    @Query("SELECT a FROM Account a " +
+            "LEFT JOIN FETCH a.profileImage " +
+            "WHERE a.username = :username")
+    Optional<Account> findByUsernameWithImage(String username);
 }

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -3,19 +3,29 @@ package com.filmdoms.community.account.service;
 import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.account.data.constants.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
+import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
+import com.filmdoms.community.account.data.dto.request.UpdatePasswordRequestDto;
+import com.filmdoms.community.account.data.dto.request.UpdateProfileRequestDto;
+import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.file.data.entity.File;
+import com.filmdoms.community.file.repository.FileRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountService {
-
+    private final FileRepository fileRepository;
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -46,21 +56,103 @@ public class AccountService {
         return accountRepository.existsByUsername(username);
     }
 
-    // TODO: 회원 가입 비즈니스 로직 구현하기
-    public AccountDto join(String username, String password) {
-        String testUsername = (username == null) ? "tester" : username;
-        String testPassword = (password == null) ? "password" : password;
-        File profileImage = File.builder()
-                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
-                .originalFileName("original_file_name")
+    public boolean isEmailDuplicate(String email) {
+        return accountRepository.existsByEmail(email);
+    }
+
+    public void createAccount(JoinRequestDto requestDto) {
+
+        log.info("아이디 중복 확인");
+        if (isUsernameDuplicate(requestDto.getUsername())) {
+            throw new ApplicationException(ErrorCode.DUPLICATE_USERNAME);
+        }
+
+        log.info("이메일 중복 확인");
+        if (isEmailDuplicate(requestDto.getEmail())) {
+            throw new ApplicationException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        log.info("Account 엔티티 생성");
+        Account newAccount = Account.builder()
+                .username(requestDto.getUsername())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .nickname(requestDto.getNickname())
+                .email(requestDto.getEmail())
+                .role(AccountRole.USER)
+                .profileImage(getDefaultImage())
                 .build();
 
-        Account testAccount = Account.builder()
-                .username(testUsername)
-                .password(passwordEncoder.encode(testPassword))
-                .role(AccountRole.USER)
-                .profileImage(profileImage)
-                .build();
-        return AccountDto.from(accountRepository.save(testAccount));
+        log.info("Account 엔티티 저장");
+        accountRepository.save(newAccount);
+    }
+
+    // TODO: 프로필 기본 이미지 어떻게 처리할 지 상의 필요
+    private File getDefaultImage() {
+        return fileRepository.findById(1L).orElse(File.builder()
+                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                .originalFileName("original_file_name")
+                .build()
+        );
+    }
+
+    public AccountResponseDto readAccount(AccountDto accountDto) {
+
+        log.info("Account 엔티티 호출");
+        Account account = accountRepository.findByUsernameWithImage(accountDto.getUsername())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        return AccountResponseDto.from(account);
+    }
+
+    @Transactional
+    public AccountResponseDto updateAccountProfile(UpdateProfileRequestDto requestDto, AccountDto accountDto) {
+
+        log.info("Account 엔티티 호출");
+        Account account = accountRepository.findByUsernameWithImage(accountDto.getUsername())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        File profileImage = account.getProfileImage();
+        if (!Objects.equals(requestDto.getFileId(), profileImage.getId())) {
+            log.info("요청 File 엔티티 호출");
+            profileImage = fileRepository.findById(requestDto.getFileId())
+                    .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_IMAGE_ID));
+        }
+
+        log.info("Account 엔티티 수정");
+        account.updateProfile(requestDto.getNickname(), profileImage);
+
+        return AccountResponseDto.from(account);
+    }
+
+    @Transactional
+    public void updateAccountPassword(UpdatePasswordRequestDto requestDto, AccountDto accountDto) {
+
+        log.info("Account 엔티티 호출");
+        Account account = accountRepository.findByUsername(accountDto.getUsername())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        log.info("기존 비밀번호와 대조");
+        if (!passwordEncoder.matches(requestDto.getOldPassword(), account.getPassword())) {
+            throw new ApplicationException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        log.info("비밀번호 수정");
+        account.updatePassword(passwordEncoder.encode(requestDto.getNewPassword()));
+    }
+
+    @Transactional
+    public void deleteAccount(DeleteAccountRequestDto requestDto, AccountDto accountDto) {
+
+        log.info("Account 엔티티 호출");
+        Account account = accountRepository.findByUsername(accountDto.getUsername())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        log.info("기존 비밀번호와 대조");
+        if (!passwordEncoder.matches(requestDto.getPassword(), account.getPassword())) {
+            throw new ApplicationException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        log.info("Account 엔티티 삭제");
+        accountRepository.delete(account);
     }
 }

--- a/src/test/java/com/filmdoms/community/account/service/AccountServiceTest.java
+++ b/src/test/java/com/filmdoms/community/account/service/AccountServiceTest.java
@@ -1,20 +1,35 @@
 package com.filmdoms.community.account.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.filmdoms.community.account.config.SecurityConfig;
 import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.account.data.constants.AccountRole;
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
+import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
+import com.filmdoms.community.account.data.dto.request.UpdatePasswordRequestDto;
+import com.filmdoms.community.account.data.dto.request.UpdateProfileRequestDto;
+import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.file.data.entity.File;
+import com.filmdoms.community.file.repository.FileRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -23,6 +38,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @WebMvcTest(
         controllers = AccountService.class,
@@ -36,6 +52,9 @@ class AccountServiceTest {
     private AccountService accountService;
 
     @MockBean
+    private FileRepository fileRepository;
+
+    @MockBean
     private AccountRepository accountRepository;
 
     @MockBean
@@ -44,57 +63,338 @@ class AccountServiceTest {
     @MockBean
     private PasswordEncoder encoder;
 
-    @Test
-    @DisplayName("올바른 ID와 비밀번호를 입력하면, 유저 정보를 반환한다.")
-    void givenCorrectUsernameAndPassword_whenTryingToLogin_thenReturnsAccountInfo() {
-        // Given
-        String username = "username";
-        String password = "password";
-        Account mockAccount = makeMockAccount(username, password);
-        when(accountRepository.findByUsername(username)).thenReturn(Optional.of(mockAccount));
-        when(encoder.matches(password, mockAccount.getPassword())).thenReturn(true);
-        when(jwtTokenProvider.createToken(any(), any())).thenReturn("mockJwtString");
+    @Nested
+    @DisplayName("로그인 기능 테스트")
+    class aboutLogin {
+        @Test
+        @DisplayName("올바른 ID와 비밀번호를 입력하면, 유저 정보를 반환한다.")
+        void givenCorrectUsernameAndPassword_whenTryingToLogin_thenReturnsAccountInfo() {
+            // Given
+            String username = "username";
+            String password = "password";
+            Account mockAccount = getMockAccount(username, password);
+            when(accountRepository.findByUsername(username)).thenReturn(Optional.of(mockAccount));
+            when(encoder.matches(password, mockAccount.getPassword())).thenReturn(true);
+            when(jwtTokenProvider.createToken(any(), any())).thenReturn("mockJwtString");
 
-        // When & Then
-        assertDoesNotThrow(() -> accountService.login(username, password));
+            // When & Then
+            assertDoesNotThrow(() -> accountService.login(username, password));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID를 입력하면, 예외를 반환한다.")
+        void givenWrongUsername_whenTryingToLogin_thenReturnsException() {
+            // Given
+            String username = "wrong_username";
+            String password = "password";
+            when(accountRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            // When & Then
+            ApplicationException e = assertThrows(ApplicationException.class,
+                    () -> accountService.login(username, password));
+            assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("일치하지 않는 비밀번호를 입력하면, 예외를 반환한다.")
+        void givenWrongPassword_whenTryingToLogin_thenReturnsException() {
+            // Given
+            String username = "username";
+            String password = "wrong_password";
+            Account mockAccount = getMockAccount(username, password);
+            when(accountRepository.findByUsername(username)).thenReturn(Optional.of(mockAccount));
+            when(encoder.matches(password, mockAccount.getPassword())).thenReturn(false);
+
+            // When & Then
+            ApplicationException e = assertThrows(ApplicationException.class,
+                    () -> accountService.login(username, password));
+            assertEquals(ErrorCode.INVALID_PASSWORD, e.getErrorCode());
+        }
     }
 
-    @Test
-    @DisplayName("존재하지 않는 ID를 입력하면, 예외를 반환한다.")
-    void givenWrongUsername_whenTryingToLogin_thenReturnsException() {
-        // Given
-        String username = "wrong_username";
-        String password = "password";
-        when(accountRepository.findByUsername(username)).thenReturn(Optional.empty());
+    @Nested
+    @DisplayName("회원가입 기능 테스트")
+    class aboutJoin {
+        @Test
+        @DisplayName("중복 아이디 확인시, 중복된 아이디를 입력하면, 참을 반환한다.")
+        void givenDuplicateUsername_whenCheckingUsername_thenReturnsTrue() {
 
-        // When & Then
-        ApplicationException e = assertThrows(ApplicationException.class,
-                () -> accountService.login(username, password));
-        assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+            // Given
+            String username = "username";
+            given(accountRepository.existsByUsername(username)).willReturn(true);
+
+            // When & Then
+            assertTrue(accountService.isUsernameDuplicate(username));
+        }
+
+        @Test
+        @DisplayName("중복 이메일 확인시, 중복된 이메일을 입력하면, 참을 반환한다.")
+        void givenDuplicateEmail_whenCheckingEmail_thenReturnsTrue() {
+
+            // Given
+            String email = "random@email.com";
+            given(accountRepository.existsByUsername(email)).willReturn(true);
+
+            // When & Then
+            assertTrue(accountService.isUsernameDuplicate(email));
+        }
+
+        @Test
+        @DisplayName("계정 생성시, 올바른 요청이라면, 계정을 저장한다.")
+        void givenValidRequest_whenCreatingAccount_thenSavesAccount() {
+
+            // Given
+            JoinRequestDto requestDto = JoinRequestDto.builder()
+                    .username("testuser")
+                    .password("PassWord!0")
+                    .email("random@email.com")
+                    .nickname("JavaNoob")
+                    .build();
+            given(accountRepository.existsByUsername(any())).willReturn(false);
+            given(accountRepository.existsByEmail(any())).willReturn(false);
+            given(fileRepository.findById(any())).willReturn(Optional.empty());
+
+            // When
+            accountService.createAccount(requestDto);
+
+            // Then
+            then(accountRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("계정 생성시, 중복된 아이디라면, 예외를 반환한다.")
+        void givenDuplicateUsername_whenCreatingAccount_thenReturnsDuplicateUsernameException() {
+
+            // Given
+            JoinRequestDto requestDto = JoinRequestDto.builder()
+                    .username("testuser")
+                    .password("PassWord!0")
+                    .email("random@email.com")
+                    .nickname("JavaNoob")
+                    .build();
+            given(accountRepository.existsByUsername(any())).willReturn(true);
+            given(accountRepository.existsByEmail(any())).willReturn(false);
+            given(fileRepository.findById(any())).willReturn(Optional.empty());
+
+            // When
+            Throwable throwable = catchThrowable(() -> accountService.createAccount(requestDto));
+
+            // Then
+            assertThat(throwable)
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(ErrorCode.DUPLICATE_USERNAME.getMessage());
+        }
+
+        @Test
+        @DisplayName("계정 생성시, 중복된 이메일이라면, 예외를 반환한다.")
+        void givenDuplicateEmail_whenCreatingAccount_thenReturnsDuplicateEmailException() {
+
+            // Given
+            JoinRequestDto requestDto = JoinRequestDto.builder()
+                    .username("testuser")
+                    .password("PassWord!0")
+                    .email("random@email.com")
+                    .nickname("JavaNoob")
+                    .build();
+            given(accountRepository.existsByUsername(any())).willReturn(false);
+            given(accountRepository.existsByEmail(any())).willReturn(true);
+            given(fileRepository.findById(any())).willReturn(Optional.empty());
+
+            // When
+            Throwable throwable = catchThrowable(() -> accountService.createAccount(requestDto));
+
+            // Then
+            assertThat(throwable)
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
+        }
     }
 
-    @Test
-    @DisplayName("일치하지 않는 비밀번호를 입력하면, 예외를 반환한다.")
-    void givenWrongPassword_whenTryingToLogin_thenReturnsException() {
-        // Given
-        String username = "username";
-        String password = "wrong_password";
-        Account mockAccount = makeMockAccount(username, password);
-        when(accountRepository.findByUsername(username)).thenReturn(Optional.of(mockAccount));
-        when(encoder.matches(password, mockAccount.getPassword())).thenReturn(false);
+    @Nested
+    @DisplayName("프로필 수정 기능 테스트")
+    class aboutUpdatingProfile {
 
-        // When & Then
-        ApplicationException e = assertThrows(ApplicationException.class,
-                () -> accountService.login(username, password));
-        assertEquals(ErrorCode.INVALID_PASSWORD, e.getErrorCode());
+        @Test
+        @DisplayName("프로필 수정시, 올바른 요청이라면, 수정된 계정 정보를 반환한다.")
+        void givenProperRequest_whenUpdatingAccountProfile_thenReturnsUpdatedAccountInformation() {
+
+            // Given
+            AccountDto mockAccountDto = mock(AccountDto.class);
+            Account mockAccount = getMockAccount("testuser", "password");
+
+            File mockNewImage = mock(File.class);
+            given(mockNewImage.getId()).willReturn(2L);
+            given(mockNewImage.getUuidFileName()).willReturn("randomUuidFileName");
+
+            UpdateProfileRequestDto requestDto = UpdateProfileRequestDto.builder()
+                    .fileId(2L)
+                    .nickname("newNickname")
+                    .build();
+            given(accountRepository.findByUsernameWithImage(any())).willReturn(Optional.of(mockAccount));
+            given(fileRepository.findById(any())).willReturn(Optional.of(mockNewImage));
+
+            // When
+            AccountResponseDto responseDto = accountService.updateAccountProfile(requestDto, mockAccountDto);
+
+            // Then
+            assertThat(responseDto)
+                    .hasFieldOrPropertyWithValue("nickname", "newNickname");
+            assertThat(responseDto.getProfileImage())
+                    .hasFieldOrPropertyWithValue("id", 2L);
+        }
+
+        @Test
+        @DisplayName("프로필 수정시, 요청 프로필 이미지가 없다면, 예외를 반환한다.")
+        void givenInvalidFileId_whenUpdatingAccountProfile_thenReturnsInvalidImageException() {
+
+            // Given
+            AccountDto mockAccountDto = mock(AccountDto.class);
+            Account mockAccount = getMockAccount("testuser", "password");
+
+            UpdateProfileRequestDto requestDto = UpdateProfileRequestDto.builder()
+                    .fileId(2L)
+                    .nickname("newNickname")
+                    .build();
+            given(accountRepository.findByUsernameWithImage(any())).willReturn(Optional.of(mockAccount));
+            given(fileRepository.findById(any())).willReturn(Optional.empty());
+
+            // When
+            Throwable throwable = catchThrowable(() -> accountService.updateAccountProfile(requestDto, mockAccountDto));
+
+            // Then
+            assertThat(throwable)
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(ErrorCode.INVALID_IMAGE_ID.getMessage());
+        }
     }
 
-    private Account makeMockAccount(String username, String password) {
-        return Account.builder()
+    @Nested
+    @DisplayName("비밀번호 수정 기능 테스트")
+    class aboutUpdatingPassword {
+
+        @Test
+        @DisplayName("비밀번호 수정시, 올바른 요청이라면, 수정된 비밀번호를 저장한다.")
+        void givenProperRequest_whenUpdatingAccountPassword_thenSavesUpdatedPassword() {
+
+            // Given
+            String newEncodedPassword = "newEncodedPassword";
+            AccountDto mockAccountDto = mock(AccountDto.class);
+            Account mockAccount = mock(Account.class);
+            given(mockAccount.getPassword()).willReturn("password");
+
+            UpdatePasswordRequestDto requestDto = UpdatePasswordRequestDto.builder()
+                    .oldPassword("password")
+                    .newPassword("newPassword")
+                    .build();
+            given(accountRepository.findByUsername(any())).willReturn(Optional.of(mockAccount));
+            given(encoder.matches(any(), any())).willReturn(true);
+            given(encoder.encode("newPassword")).willReturn(newEncodedPassword);
+
+            // When
+            accountService.updateAccountPassword(requestDto, mockAccountDto);
+
+            // Then
+            then(mockAccount).should().updatePassword(newEncodedPassword);
+        }
+
+        @Test
+        @DisplayName("비밀번호 수정시, 틀린 비밀번호를 입력하면, 예외를 반환한다.")
+        void givenInvalidPassword_whenUpdatingAccountPassword_thenReturnsException() {
+
+            // Given
+            String newEncodedPassword = "newEncodedPassword";
+            AccountDto mockAccountDto = mock(AccountDto.class);
+            Account mockAccount = mock(Account.class);
+            given(mockAccount.getPassword()).willReturn("password");
+
+            UpdatePasswordRequestDto requestDto = UpdatePasswordRequestDto.builder()
+                    .oldPassword("wrongPassword")
+                    .newPassword("newPassword")
+                    .build();
+            given(accountRepository.findByUsername(any())).willReturn(Optional.of(mockAccount));
+            given(encoder.matches(any(), any())).willReturn(false);
+            given(encoder.encode("newPassword")).willReturn(newEncodedPassword);
+
+            // When
+            Throwable throwable = catchThrowable(
+                    () -> accountService.updateAccountPassword(requestDto, mockAccountDto));
+
+            // Then
+            assertThat(throwable)
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("계정 삭제 기능 테스트")
+    class aboutDeletingAccount {
+
+        @Test
+        @DisplayName("계정 삭제시, 올바른 요청이라면, 요청된 계정을 삭제한다.")
+        void givenProperRequest_whenDeletingAccount_thenDeletesAccount() {
+
+            // Given
+            AccountDto mockAccountDto = mock(AccountDto.class);
+            Account mockAccount = mock(Account.class);
+            given(mockAccount.getPassword()).willReturn("password");
+
+            DeleteAccountRequestDto requestDto = DeleteAccountRequestDto.builder()
+                    .password("password")
+                    .build();
+            given(accountRepository.findByUsername(any())).willReturn(Optional.of(mockAccount));
+            given(encoder.matches("password", "password")).willReturn(true);
+
+            // When
+            accountService.deleteAccount(requestDto, mockAccountDto);
+
+            // Then
+            then(accountRepository).should().delete(mockAccount);
+        }
+
+        @Test
+        @DisplayName("계정 삭제시, 틀린 비밀번호를 입력하면, 예외를 반환한다.")
+        void givenInvalidPassword_whenDeletingAccount_thenReturnsException() {
+
+            // Given
+            AccountDto mockAccountDto = mock(AccountDto.class);
+            Account mockAccount = mock(Account.class);
+            given(mockAccount.getPassword()).willReturn("password");
+
+            DeleteAccountRequestDto requestDto = DeleteAccountRequestDto.builder()
+                    .password("wrongPassword")
+                    .build();
+            given(accountRepository.findByUsername(any())).willReturn(Optional.of(mockAccount));
+            given(encoder.matches("wrongPassword", "password")).willReturn(false);
+
+            // When
+            Throwable throwable = catchThrowable(
+                    () -> accountService.deleteAccount(requestDto, mockAccountDto));
+
+            // Then
+            assertThat(throwable)
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+        }
+    }
+
+    private Account getMockAccount(String username, String password) {
+
+        File mockOriginalImage = mock(File.class);
+        given(mockOriginalImage.getId()).willReturn(1L);
+
+        Account mockAccount = Account.builder()
                 .username(username)
                 .password(password)
+                .nickname("oldNickname")
+                .email("random@email.com")
                 .role(AccountRole.USER)
+                .isSocialLogin(false)
+                .profileImage(mockOriginalImage)
                 .build();
-    }
+        ReflectionTestUtils.setField(mockAccount, Account.class, "id", 1L, Long.class);
+        ReflectionTestUtils.setField(mockAccount, Account.class, "isSocialLogin", false, boolean.class);
 
+        return mockAccount;
+    }
 }


### PR DESCRIPTION
회원 관련 CRUD 기능을 구현했습니다. (회원 가입, 아이디 중복 체크, 이메일 중복 체크, 프로필 수정, 비밀번호 수정, 계정 삭제)

수정된 로그인 기능 URI를 포함해 각각의 URI는 다음과 같습니다:
```
POST /api/v1/account/login : 로그인
POST /api/v1/account : 회원가입
GET /api/v1/account/check/username : 유저명 중복 확인
GET /api/v1/account/check/email : 이메일 중복 확인
GET /api/v1/account/profile : 프로필 조회
PUT /api/v1/account/profile : 프로필 수정
PUT /api/v1/account/profile/password : 비밀번호 수정
DELETE /api/v1/account/ : 계정 삭제
```

### 참고 사항
* 회원 가입시 받는 정보에 대해 제한 사항을 임의로 추가했습니다. 추후 기획자님과 논의가 필요합니다.
  * username: 8자 이상, 20자 이하의 알파벳, 숫자, "_" 의 조합 (선택적 조합)
  * password: 8자 이상, 100자 이하의 소문자, 대문자, 숫자, 특수문자의 조합 (필수적 조합)
  * email: "xxx@xxx.xx" 의 이메일 형식
  * nickname: 2자 이상, 20자 이하의 문자