### PR TITLE
최근 게시물 및 인기 게시글 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
+++ b/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
@@ -10,6 +10,7 @@ import com.filmdoms.community.article.data.dto.response.boardlist.RecentListResp
 import com.filmdoms.community.article.data.dto.response.detail.ArticleDetailResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.MovieAndRecentMainPageResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.ParentMainPageResponseDto;
+import com.filmdoms.community.article.data.dto.response.trending.TopFiveArticleResponseDto;
 import com.filmdoms.community.article.service.ArticleService;
 import com.filmdoms.community.article.service.InitService;
 import lombok.RequiredArgsConstructor;
@@ -86,5 +87,11 @@ public class ArticleController2 {
             return Response.error(ErrorCode.INVALID_PAGE_NUMBER.getMessage());
 
         return Response.success(boardList);
+    }
+
+    @GetMapping("/article/top-posts")
+    public Response getTopPosts() {
+        List<TopFiveArticleResponseDto> topFiveArticles = articleService.getTopFiveArticles();
+        return Response.success(topFiveArticles);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
+++ b/src/main/java/com/filmdoms/community/article/controller/ArticleController2.java
@@ -6,6 +6,7 @@ import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.constant.Tag;
 import com.filmdoms.community.article.data.dto.response.boardlist.ParentBoardListResponseDto;
+import com.filmdoms.community.article.data.dto.response.boardlist.RecentListResponseDto;
 import com.filmdoms.community.article.data.dto.response.detail.ArticleDetailResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.MovieAndRecentMainPageResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.ParentMainPageResponseDto;
@@ -54,6 +55,20 @@ public class ArticleController2 {
     public Response initData(@RequestParam(defaultValue = "10") int limit) {
         initService.makeArticleData(limit);
         return Response.success();
+    }
+
+    @GetMapping("/article/recent")
+    public Response getRecentArticles(@RequestParam(required = false) Tag tag, @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        if (pageable.getPageSize() > 50)
+            pageable = PageRequest.of(pageable.getPageNumber(), 24, Sort.by(Sort.Direction.DESC, "id")); //Article의 id로 역정렬
+        Page<RecentListResponseDto> recentArticles = articleService.getRecentArticles(tag, pageable);
+
+        if (recentArticles.getTotalPages() - 1 < pageable.getPageNumber())
+            return Response.error(ErrorCode.INVALID_PAGE_NUMBER.getMessage());
+
+        return Response.success(recentArticles);
+
+
     }
 
     @GetMapping("/article/{category}")

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/boardlist/RecentListResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/boardlist/RecentListResponseDto.java
@@ -1,0 +1,14 @@
+package com.filmdoms.community.article.data.dto.response.boardlist;
+
+import com.filmdoms.community.article.data.entity.Article;
+
+public class RecentListResponseDto extends ParentBoardListResponseDto {
+
+    public RecentListResponseDto(Article article) {
+        super(article);
+    }
+
+    public static RecentListResponseDto from(Article article) {
+        return new RecentListResponseDto(article);
+    }
+}

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/trending/TopFiveArticleResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/trending/TopFiveArticleResponseDto.java
@@ -7,17 +7,20 @@ import lombok.Getter;
 @Getter
 public class TopFiveArticleResponseDto {
 
-    Long id;
-    String title;
-    SimpleAccountResponseDto author;
+    private Long id;
+    private String title;
+    private SimpleAccountResponseDto author;
+    private boolean containsImage;
 
-    public TopFiveArticleResponseDto(Long id, String title, SimpleAccountResponseDto author) {
+
+    public TopFiveArticleResponseDto(Long id, String title, SimpleAccountResponseDto author, boolean containsImage) {
         this.id = id;
         this.title = title;
+        this.containsImage = containsImage;
         this.author = author;
     }
 
     public static TopFiveArticleResponseDto from(Article article) {
-        return new TopFiveArticleResponseDto(article.getId(), article.getTitle(), SimpleAccountResponseDto.from(article.getAuthor()));
+        return new TopFiveArticleResponseDto(article.getId(), article.getTitle(), SimpleAccountResponseDto.from(article.getAuthor()), article.isContainsImage());
     }
 }

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/trending/TopFiveArticleResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/trending/TopFiveArticleResponseDto.java
@@ -1,0 +1,23 @@
+package com.filmdoms.community.article.data.dto.response.trending;
+
+import com.filmdoms.community.account.data.dto.response.SimpleAccountResponseDto;
+import com.filmdoms.community.article.data.entity.Article;
+import lombok.Getter;
+
+@Getter
+public class TopFiveArticleResponseDto {
+
+    Long id;
+    String title;
+    SimpleAccountResponseDto author;
+
+    public TopFiveArticleResponseDto(Long id, String title, SimpleAccountResponseDto author) {
+        this.id = id;
+        this.title = title;
+        this.author = author;
+    }
+
+    public static TopFiveArticleResponseDto from(Article article) {
+        return new TopFiveArticleResponseDto(article.getId(), article.getTitle(), SimpleAccountResponseDto.from(article.getAuthor()));
+    }
+}

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/trending/TopFiveArticleResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/trending/TopFiveArticleResponseDto.java
@@ -1,6 +1,7 @@
 package com.filmdoms.community.article.data.dto.response.trending;
 
 import com.filmdoms.community.account.data.dto.response.SimpleAccountResponseDto;
+import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.entity.Article;
 import lombok.Getter;
 
@@ -12,15 +13,18 @@ public class TopFiveArticleResponseDto {
     private SimpleAccountResponseDto author;
     private boolean containsImage;
 
+    private Category category;
 
-    public TopFiveArticleResponseDto(Long id, String title, SimpleAccountResponseDto author, boolean containsImage) {
+
+    public TopFiveArticleResponseDto(Long id, String title, SimpleAccountResponseDto author, boolean containsImage, Category category) {
         this.id = id;
         this.title = title;
+        this.category = category;
         this.containsImage = containsImage;
         this.author = author;
     }
 
     public static TopFiveArticleResponseDto from(Article article) {
-        return new TopFiveArticleResponseDto(article.getId(), article.getTitle(), SimpleAccountResponseDto.from(article.getAuthor()), article.isContainsImage());
+        return new TopFiveArticleResponseDto(article.getId(), article.getTitle(), SimpleAccountResponseDto.from(article.getAuthor()), article.isContainsImage(), article.getCategory());
     }
 }

--- a/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
@@ -33,4 +33,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             , countQuery = "SELECT count(a) from Article a where a.category =: categoryId and a.tag =: tagId")
     Page<Article> findArticlesByCategoryAndTag(@Param("categoryId") Category category, @Param("tagId") Tag tag, Pageable pageable);
 
+    @Query(value = "SELECT a from Article a inner join fetch  a.author join fetch  a.author.profileImage"
+            ,countQuery =  "SELECT count(a) FROM  Article a")
+    Page<Article> getAllArticles(Pageable pageable);
+
+    @Query(value = "SELECT a from Article a inner join fetch  a.author join fetch  a.author.profileImage where a.tag =:tagId"
+            ,countQuery =  "SELECT count(a) FROM  Article a where a.tag =:tagId")
+    Page<Article> getAllArticlesByTag(@Param("tagId") Tag tag, Pageable pageable);
+
 }

--- a/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
@@ -41,4 +41,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             ,countQuery =  "SELECT count(a) FROM  Article a where a.tag =:tagId")
     Page<Article> getAllArticlesByTag(@Param("tagId") Tag tag, Pageable pageable);
 
+    @Query(value = "SELECT a from Article a inner join fetch a.author order by a.voteCount desc limit 5")
+    List<Article> getTop5Articles();
+
 }

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -9,10 +9,7 @@ import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.constant.Tag;
 import com.filmdoms.community.article.data.dto.ArticleControllerToServiceDto;
 import com.filmdoms.community.article.data.dto.filmuniverse.FilmUniverseControllerToServiceDto;
-import com.filmdoms.community.article.data.dto.response.boardlist.CriticListResponseResponseDto;
-import com.filmdoms.community.article.data.dto.response.boardlist.FilmUniverseListResponseResponseDto;
-import com.filmdoms.community.article.data.dto.response.boardlist.MovieListResponseResponseDto;
-import com.filmdoms.community.article.data.dto.response.boardlist.ParentBoardListResponseDto;
+import com.filmdoms.community.article.data.dto.response.boardlist.*;
 import com.filmdoms.community.article.data.dto.response.detail.ArticleDetailResponseDto;
 import com.filmdoms.community.article.data.dto.response.detail.FilmUniverseDetailResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.CriticMainPageResponseDto;
@@ -146,6 +143,19 @@ public class ArticleService {
             return voteRepository.findByVoteKey(voteKey).isPresent();
         }
         return false; //로그인하지 않은 익명 사용자의 경우 항상 false를 반환
+    }
+
+    public Page<RecentListResponseDto> getRecentArticles(Tag tag, Pageable pageable) {
+
+        Page<Article> articles;
+
+        if (tag == null)
+            articles = articleRepository.getAllArticles(pageable);
+        else
+            articles = articleRepository.getAllArticlesByTag(tag, pageable);
+
+        Page<RecentListResponseDto> recentListResponseDtos = articles.map(RecentListResponseDto::from);
+        return recentListResponseDtos;
     }
 
     public Page<? extends ParentBoardListResponseDto> getBoardList(Category category, Tag tag, Pageable pageable) {

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -16,6 +16,7 @@ import com.filmdoms.community.article.data.dto.response.mainpage.CriticMainPageR
 import com.filmdoms.community.article.data.dto.response.mainpage.FilmUniverseMainPageResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.MovieAndRecentMainPageResponseDto;
 import com.filmdoms.community.article.data.dto.response.mainpage.ParentMainPageResponseDto;
+import com.filmdoms.community.article.data.dto.response.trending.TopFiveArticleResponseDto;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.article.data.entity.extra.Critic;
 import com.filmdoms.community.article.data.entity.extra.FilmUniverse;
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -192,6 +194,12 @@ public class ArticleService {
 
         return null;
 
+    }
+
+    public List<TopFiveArticleResponseDto> getTopFiveArticles() {
+        List<Article> top5Articles = articleRepository.getTop5Articles();
+        List<TopFiveArticleResponseDto> topFiveArticleResponseDtos = top5Articles.stream().map(TopFiveArticleResponseDto::from).collect(Collectors.toList());
+        return topFiveArticleResponseDtos;
     }
 
 

--- a/src/main/java/com/filmdoms/community/article/service/InitService.java
+++ b/src/main/java/com/filmdoms/community/article/service/InitService.java
@@ -71,6 +71,8 @@ public class InitService {
                     .content("Movie 게시판 " + i + "번째 글 내용\nMovie 게시판 " + i + "번째 글 내용")
                     .containsImage(false)
                     .build();
+            for(int p=i; p<=limit-3; p++)
+                article.addVote();
             articleRepository.save(article);
 
 //            FileContent fileContent = FileContent.builder()
@@ -93,6 +95,7 @@ public class InitService {
                         .author(admin)
                         .content("Movie 게시판 " + i + "번째 글의 " + j + "번째 댓글 내용")
                         .build();
+
                 newCommentRepository.save(comment);
 
                 for (int k = 1; k < 3; k++) {
@@ -119,6 +122,8 @@ public class InitService {
                     .containsImage(true)
                     .content("File Universe 게시판 " + i + "번째 글 내용\nFile Universe 게시판 " + i + "번째 글 내용")
                     .build();
+            for(int p=i/3; p<=limit/2; p++)
+                article.addVote();
 
             FilmUniverse filmUniverse = FilmUniverse.builder()
                     .mainImage(defaultImage)
@@ -174,7 +179,8 @@ public class InitService {
                     .containsImage(true)
                     .content("Critic 게시판 " + i + "번째 글 내용\nCritic 게시판 " + i + "번째 글 내용")
                     .build();
-
+            for(int p=i; p<=limit-10; p++)
+                article.addVote();
             Critic critic = Critic.builder()
                     .article(article)
                     .mainImage(defaultImage)


### PR DESCRIPTION
최근 게시물 조회 api/v1/article/recent  
인기 게시글 조회 api/v1/article/top-posts

기능을 구현하였습니다.

최근 게시물의 경우에는 이전에 개별 게시판과 기능 자체는 똑같이 동작하나, repository 쿼리가 조금 달라져서 그부분 이 조금 다른 것 같고 대부분의 로직이 개별 게시판 기능과 동일합니다.

인기게시물의 경우에는 현재 좋아요 갯수로 정렬하게 설정하였고, 추가적인 로직이 생긴다면 서비스 부분 코드 수정하면 될것 같습니다!