### PR TITLE
댓글 추천 기능 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/newcomment/controller/NewCommentController.java
+++ b/src/main/java/com/filmdoms/community/newcomment/controller/NewCommentController.java
@@ -7,10 +7,18 @@ import com.filmdoms.community.newcomment.data.dto.request.NewCommentCreateReques
 import com.filmdoms.community.newcomment.data.dto.request.NewCommentUpdateRequestDto;
 import com.filmdoms.community.newcomment.data.dto.response.DetailPageCommentResponseDto;
 import com.filmdoms.community.newcomment.data.dto.response.NewCommentCreateResponseDto;
+import com.filmdoms.community.newcomment.data.dto.response.NewCommentVoteResponseDto;
 import com.filmdoms.community.newcomment.service.NewCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -26,13 +34,21 @@ public class NewCommentController {
     }
 
     @PostMapping("/comment")
-    public Response<NewCommentCreateResponseDto> create(@RequestBody NewCommentCreateRequestDto requestDto, @AuthenticationPrincipal AccountDto accountDto) {
+    public Response<NewCommentCreateResponseDto> create(@RequestBody NewCommentCreateRequestDto requestDto,
+                                                        @AuthenticationPrincipal AccountDto accountDto) {
         NewCommentCreateResponseDto responseDto = newCommentService.createComment(requestDto, accountDto);
         return Response.success(responseDto);
     }
 
+    @PostMapping("/comment/{commentId}/vote")
+    public Response<NewCommentVoteResponseDto> vote(@PathVariable Long commentId,
+                                                    @AuthenticationPrincipal AccountDto accountDto) {
+        return Response.success(newCommentService.toggleCommentVote(commentId, accountDto));
+    }
+
     @PutMapping("/comment/{commentId}")
-    public Response update(@RequestBody NewCommentUpdateRequestDto requestDto, @PathVariable Long commentId, @AuthenticationPrincipal AccountDto accountDto) {
+    public Response update(@RequestBody NewCommentUpdateRequestDto requestDto, @PathVariable Long commentId,
+                           @AuthenticationPrincipal AccountDto accountDto) {
         newCommentService.updateComment(requestDto, commentId, accountDto);
         return Response.success();
     }

--- a/src/main/java/com/filmdoms/community/newcomment/data/dto/response/NewCommentVoteResponseDto.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/dto/response/NewCommentVoteResponseDto.java
@@ -1,0 +1,16 @@
+package com.filmdoms.community.newcomment.data.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class NewCommentVoteResponseDto {
+
+    private Boolean isVoted;
+    private Integer voteCount;
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewComment.java
@@ -4,7 +4,18 @@ import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.board.data.BaseTimeEntity;
 import com.filmdoms.community.board.data.constant.CommentStatus;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,7 +56,8 @@ public class NewComment extends BaseTimeEntity {
     private boolean isManagerComment;
 
     @Builder
-    private NewComment(Article article, NewComment parentComment, Account author, String content, boolean isManagerComment) {
+    private NewComment(Article article, NewComment parentComment, Account author, String content,
+                       boolean isManagerComment) {
         this.article = article;
         this.parentComment = parentComment;
         this.author = author;
@@ -59,5 +71,13 @@ public class NewComment extends BaseTimeEntity {
 
     public void changeStatusToDeleted() {
         this.status = CommentStatus.DELETED;
+    }
+
+    public int removeVote() {
+        return --voteCount;
+    }
+
+    public int addVote() {
+        return ++voteCount;
     }
 }

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewCommentVote.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewCommentVote.java
@@ -1,0 +1,18 @@
+package com.filmdoms.community.newcomment.data.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NewCommentVote {
+
+    @EmbeddedId
+    private NewCommentVoteKey voteKey;
+}

--- a/src/main/java/com/filmdoms/community/newcomment/data/entity/NewCommentVoteKey.java
+++ b/src/main/java/com/filmdoms/community/newcomment/data/entity/NewCommentVoteKey.java
@@ -1,0 +1,29 @@
+package com.filmdoms.community.newcomment.data.entity;
+
+import com.filmdoms.community.account.data.entity.Account;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NewCommentVoteKey implements Serializable {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private NewComment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+}

--- a/src/main/java/com/filmdoms/community/newcomment/repository/NewCommentVoteRepository.java
+++ b/src/main/java/com/filmdoms/community/newcomment/repository/NewCommentVoteRepository.java
@@ -1,0 +1,11 @@
+package com.filmdoms.community.newcomment.repository;
+
+import com.filmdoms.community.newcomment.data.entity.NewCommentVote;
+import com.filmdoms.community.newcomment.data.entity.NewCommentVoteKey;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewCommentVoteRepository extends JpaRepository<NewCommentVote, NewCommentVoteKey> {
+
+    Optional<NewCommentVote> findByVoteKey(NewCommentVoteKey voteKey);
+}

--- a/src/main/java/com/filmdoms/community/newcomment/service/NewCommentService.java
+++ b/src/main/java/com/filmdoms/community/newcomment/service/NewCommentService.java
@@ -14,15 +14,19 @@ import com.filmdoms.community.newcomment.data.dto.request.NewCommentCreateReques
 import com.filmdoms.community.newcomment.data.dto.request.NewCommentUpdateRequestDto;
 import com.filmdoms.community.newcomment.data.dto.response.DetailPageCommentResponseDto;
 import com.filmdoms.community.newcomment.data.dto.response.NewCommentCreateResponseDto;
+import com.filmdoms.community.newcomment.data.dto.response.NewCommentVoteResponseDto;
 import com.filmdoms.community.newcomment.data.entity.NewComment;
+import com.filmdoms.community.newcomment.data.entity.NewCommentVote;
+import com.filmdoms.community.newcomment.data.entity.NewCommentVoteKey;
 import com.filmdoms.community.newcomment.repository.NewCommentRepository;
+import com.filmdoms.community.newcomment.repository.NewCommentVoteRepository;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -33,6 +37,7 @@ public class NewCommentService {
     private final NewCommentRepository commentRepository;
     private final ArticleRepository articleRepository;
     private final AccountRepository accountRepository;
+    private final NewCommentVoteRepository newCommentVoteRepository;
 
     public DetailPageCommentResponseDto getDetailPageCommentList(Long articleId) {
         List<NewComment> comments = commentRepository.findByArticleIdWithAuthorProfileImage(articleId);
@@ -40,13 +45,15 @@ public class NewCommentService {
     }
 
     public NewCommentCreateResponseDto createComment(NewCommentCreateRequestDto requestDto, AccountDto accountDto) {
-        Article article = articleRepository.findById(requestDto.getArticleId()).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_ARTICLE_ID));
+        Article article = articleRepository.findById(requestDto.getArticleId())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_ARTICLE_ID));
 
         Account author = accountRepository.getReferenceById(accountDto.getId());
 
         NewComment parentComment = null;
         if (requestDto.getParentCommentId() != null) {
-            parentComment = commentRepository.findById(requestDto.getParentCommentId()).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_PARENT_COMMENT_ID));
+            parentComment = commentRepository.findById(requestDto.getParentCommentId())
+                    .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_PARENT_COMMENT_ID));
 
             //위에서 조회한 Article 엔티티가 부모 댓글에 매핑된 Article 엔티티와 동일한지 확인
             if (!Objects.equals(parentComment.getArticle().getId(), article.getId())) {
@@ -74,13 +81,16 @@ public class NewCommentService {
 
     private void checkManagerCommentPermission(AccountDto accountDto, Article article) {
         //일단 관리자 댓글은 공지 게시판에서 공지 작성자와 ADMIN에 의해서만 생성되도록 함
-        if (article.getCategory() != Category.FILM_UNIVERSE || (!Objects.equals(article.getAuthor().getId(), accountDto.getId()) && accountDto.getAccountRole() != AccountRole.ADMIN)) {
+        if (article.getCategory() != Category.FILM_UNIVERSE || (
+                !Objects.equals(article.getAuthor().getId(), accountDto.getId())
+                        && accountDto.getAccountRole() != AccountRole.ADMIN)) {
             throw new ApplicationException(ErrorCode.MANAGER_COMMENT_CANNOT_BE_CREATED);
         }
     }
 
     public void updateComment(NewCommentUpdateRequestDto requestDto, Long commentId, AccountDto accountDto) {
-        NewComment comment = commentRepository.findById(commentId).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
+        NewComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
 
         //ACTIVE 상태인 댓글만 수정 가능
         checkCommentStatus(comment);
@@ -92,7 +102,8 @@ public class NewCommentService {
     }
 
     public void deleteComment(Long commentId, AccountDto accountDto) {
-        NewComment comment = commentRepository.findById(commentId).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
+        NewComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
 
         //ACTIVE 상태인 댓글만 삭제 가능
         checkCommentStatus(comment);
@@ -126,5 +137,44 @@ public class NewCommentService {
         if (comment.getStatus() != CommentStatus.ACTIVE) {
             throw new ApplicationException(ErrorCode.COMMENT_NOT_ACTIVE);
         }
+    }
+
+    public NewCommentVoteResponseDto toggleCommentVote(Long commentId, AccountDto accountDto) {
+
+        log.info("계정 호출");
+        Account account = accountRepository.getReferenceById(accountDto.getId());
+
+        log.info("댓글 호출");
+        NewComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
+
+        log.info("추천용 키 생성");
+        NewCommentVoteKey voteKey = NewCommentVoteKey.builder()
+                .account(account)
+                .comment(comment)
+                .build();
+
+        log.info("추천 여부 확인");
+        Optional<NewCommentVote> foundVote = newCommentVoteRepository.findByVoteKey(voteKey);
+        int voteCount;
+        boolean pressedResult;
+
+        if (foundVote.isPresent()) {
+            log.info("추천 취소");
+            newCommentVoteRepository.delete(foundVote.get());
+            voteCount = comment.removeVote();
+            pressedResult = false;
+        } else {
+            log.info("추천 생성");
+            newCommentVoteRepository.save(new NewCommentVote(voteKey));
+            voteCount = comment.addVote();
+            pressedResult = true;
+        }
+
+        log.info("추천 결과 반환");
+        return NewCommentVoteResponseDto.builder()
+                .voteCount(voteCount)
+                .isVoted(pressedResult)
+                .build();
     }
 }


### PR DESCRIPTION
추천 안한 댓글을 누르면 추천을 적용하고, 아니면 추천을 삭제하는 기능을 구현했습니다.
API는 다음과 같습니다:
```
POST /api/v1/comment/{commentId}/vote
```
JWT 토큰과 함께 해당 API로 요청을 보내면, 상기된 기능을 적용한 후, 응답으로 추천 수와 추천 여부를 반환합니다.

### 참고 사항

추천 기능은 댓글 기능의 하위 기능이라고 판단했기 때문에, 댓글 추천 기능을 Vote 패키지가 아닌, 기존의 NewComment 하위 패키지에 작성했습니다. 추후 게시글 추천 기능도 Vote 패키지에서 Article 패키지 밑으로 리팩토링 진행시킬 예정입니다.