### PR TITLE
이메일 인증/임시 비밀번호 발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/filmdoms/community/account/config/AsyncConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/AsyncConfig.java
@@ -1,0 +1,35 @@
+package com.filmdoms.community.account.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean
+    public Executor mailAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3); // 기본 실행 대기 중 스레드 개수
+        executor.setMaxPoolSize(10); // 동시 동작하는 최대 스레드 개수
+        executor.setQueueCapacity(100); // CorePool 초과 시 Queue에 저장해 둔 후 꺼내서 실행
+        executor.setThreadNamePrefix("MailAsyncExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("Exception handler for async method '" + method.toGenericString()
+                        + "' threw unexpected exception itself. message={}", ex.getMessage());
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/config/RedisConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.filmdoms.community.account.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/controller/EmailController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/EmailController.java
@@ -1,0 +1,37 @@
+package com.filmdoms.community.account.controller;
+
+import com.filmdoms.community.account.data.dto.request.AuthCodeVerificationRequestDto;
+import com.filmdoms.community.account.data.dto.request.SimpleEmailRequestDto;
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.account.data.dto.response.SimpleAccountResponseDto;
+import com.filmdoms.community.account.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping("/auth-code")
+    public Response<Void> sendAuthCodeEmail(@RequestBody SimpleEmailRequestDto requestDto) {
+        emailService.sendAuthCodeEmail(requestDto.getEmail());
+        return Response.success();
+    }
+
+    @PostMapping("/auth-code/verification")
+    public Response<SimpleAccountResponseDto> verifyAuthCode(@RequestBody AuthCodeVerificationRequestDto requestDto) {
+        SimpleAccountResponseDto responseDto = emailService.verityAuthCode(requestDto);
+        return Response.success(responseDto);
+    }
+
+    @PostMapping("/temp-password")
+    public Response<Void> sendTempPasswordEmail(@RequestBody SimpleEmailRequestDto requestDto) {
+        emailService.sendTempPasswordEmail(requestDto.getEmail());
+        return Response.success();
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/AuthCodeVerificationRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/AuthCodeVerificationRequestDto.java
@@ -1,0 +1,14 @@
+package com.filmdoms.community.account.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AuthCodeVerificationRequestDto {
+
+    private String email;
+    private String authCode;
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/SimpleEmailRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/SimpleEmailRequestDto.java
@@ -1,0 +1,11 @@
+package com.filmdoms.community.account.data.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SimpleEmailRequestDto {
+
+    private String email;
+}

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -33,10 +33,11 @@ public enum ErrorCode {
     MANAGER_COMMENT_CANNOT_BE_CREATED(HttpStatus.BAD_REQUEST, "관리자 댓글을 생성할 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "중복된 회원 ID 입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "중복된 회원 이메일 입니다."),
-
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
     MAIN_IMAGE_ID_NOT_IN_CONTENT_IMAGE_ID_LIST(HttpStatus.BAD_REQUEST, "메인 이미지 ID는 전체 이미지 ID 리스트에 포함되어야 합니다."),
-    NOT_SOCIAL_LOGIN_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 로그인 계정이 아닙니다.")
-    ;
+    NOT_SOCIAL_LOGIN_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 로그인 계정이 아닙니다."),
+    SOCIAL_LOGIN_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 로그인 계정입니다."),
+    INVALID_AUTHENTICATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 코드이거나 인증 코드가 만료되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/filmdoms/community/account/service/AsyncEmailSendService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AsyncEmailSendService.java
@@ -1,0 +1,35 @@
+package com.filmdoms.community.account.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncEmailSendService {
+
+    private final JavaMailSender emailSender;
+
+    @Async("mailAsyncExecutor")
+    public void sendEmail(String email, String subject, String content, boolean html, boolean multipart) {
+        try {
+            MimeMessage mimeMessage = emailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, multipart);
+
+            helper.setTo(email);
+            helper.setSubject(subject);
+            helper.setText(content, html);
+
+            emailSender.send(mimeMessage);
+
+        } catch (MessagingException e) {
+            log.error("Exception thrown during email submission, message={}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/service/EmailService.java
+++ b/src/main/java/com/filmdoms/community/account/service/EmailService.java
@@ -1,0 +1,106 @@
+package com.filmdoms.community.account.service;
+
+import com.filmdoms.community.account.data.dto.request.AuthCodeVerificationRequestDto;
+import com.filmdoms.community.account.data.dto.response.SimpleAccountResponseDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.service.utils.PasswordUtil;
+import com.filmdoms.community.account.service.utils.RedisUtil;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final AccountRepository accountRepository;
+    private final AsyncEmailSendService asyncEmailSendService;
+    private final RedisUtil redisUtil;
+    private static final long AUTH_CODE_EXPIRE_DURATION_IN_MILLISECONDS = 10 * 60 * 1000L;
+    private static final String AUTH_CODE_KEY_PREFIX = "authCode:";
+
+    public void sendTempPasswordEmail(String email) {
+        Account account = findAccountByEmailAndVerify(email);
+        String tempPassword = PasswordUtil.generateRandomPassword(10);
+        account.updatePassword(tempPassword);
+        String subject = "[필름덤즈] 임시 비밀번호를 발송해 드립니다.";
+        String content = getTempPasswordEmailContent(tempPassword);
+        asyncEmailSendService.sendEmail(email, subject, content, true, false);
+    }
+
+    public void sendAuthCodeEmail(String email) {
+        findAccountByEmailAndVerify(email);
+        String authCode = UUID.randomUUID().toString();
+        redisUtil.setDataAndExpirationInMillis(AUTH_CODE_KEY_PREFIX + email, authCode, AUTH_CODE_EXPIRE_DURATION_IN_MILLISECONDS);
+        String subject = "[필름덤즈] 인증 코드를 발송해 드립니다.";
+        String content = getAuthEmailContent(authCode);
+        asyncEmailSendService.sendEmail(email, subject, content, true, false);
+    }
+
+    public SimpleAccountResponseDto verityAuthCode(AuthCodeVerificationRequestDto requestDto) {
+        String email = requestDto.getEmail();
+        String authCode = requestDto.getAuthCode();
+        Account account = findAccountByEmailAndVerify(email);
+        String foundValue = redisUtil.getData(AUTH_CODE_KEY_PREFIX + email);
+        if (foundValue == null || !foundValue.equals(authCode)) {
+            throw new ApplicationException(ErrorCode.INVALID_AUTHENTICATION_CODE);
+        }
+
+        /*
+        인증된 계정으로 전환하는 작업 수행
+         */
+
+        log.info("Account has been authenticated. email={}, username={}", email, account.getUsername());
+        return SimpleAccountResponseDto.from(account);
+    }
+
+    private Account findAccountByEmailAndVerify(String email) {
+        Account account = accountRepository.findByEmail(email).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_EMAIL));
+        if (account.isSocialLogin()) {
+            throw new ApplicationException(ErrorCode.SOCIAL_LOGIN_ACCOUNT);
+        }
+        return account;
+    }
+
+    private String getAuthEmailContent(String authCode) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div style='margin:20px;'>");
+        sb.append("<p>필름덤즈 커뮤니티 인증 코드를 발송해 드립니다.</p>");
+        sb.append("<br>");
+        sb.append("<div align='center' style='border:1px solid black; font-family:verdana'>");
+        sb.append("<h3>인증 코드</h3>");
+        sb.append("<div style='font-size:130%'>");
+        sb.append("<strong>");
+        sb.append(authCode + "</strong></div><br/>");
+        sb.append("</div></br></br>");
+        sb.append("<p>감사합니다.</p>");
+        sb.append("</div>");
+        return sb.toString();
+    }
+
+    private String getTempPasswordEmailContent(String tempPassword) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div style='margin:20px;'>");
+        sb.append("<p>필름덤즈 커뮤니티 임시 비밀번호를 발송해 드립니다.</p>");
+        sb.append("<br>");
+        sb.append("<div align='center' style='border:1px solid black; font-family:verdana'>");
+        sb.append("<h3>임시 비밀번호</h3>");
+        sb.append("<div style='font-size:130%'>");
+        sb.append("<strong>");
+        sb.append(tempPassword + "</strong></div><br/>");
+        sb.append("</div></br></br>");
+        sb.append("<p>로그인 후에 비밀번호를 꼭 변경해 주세요.<p>");
+        sb.append("<p>감사합니다.</p>");
+        sb.append("</div>");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/service/utils/PasswordUtil.java
+++ b/src/main/java/com/filmdoms/community/account/service/utils/PasswordUtil.java
@@ -1,0 +1,46 @@
+package com.filmdoms.community.account.service.utils;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PasswordUtil {
+
+    private static String upperCases = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static String lowerCases = "abcdefghijklmnopqrstuvwxyz";
+    private static String specials = "@$!%*#?&";
+    private static String numbers = "0123456789";
+
+    public static String generateRandomPassword(int passwordLength) {
+        if (passwordLength < 8) { //변경 가능
+            throw new IllegalArgumentException("최소 비밀번호 길이는 8입니다.");
+        }
+
+        SecureRandom random = new SecureRandom();
+        List<Character> charList = new ArrayList<>();
+
+        //대문자, 소문자, 특수문자, 숫자를 1/4씩 넣기
+        int quarter = passwordLength / 4;
+        IntStream.range(0, quarter)
+                .forEach(i -> charList.add(extractRandomCharacter(upperCases, random)));
+        IntStream.range(0, quarter)
+                .forEach(i -> charList.add(extractRandomCharacter(lowerCases, random)));
+        IntStream.range(0, quarter)
+                .forEach(i -> charList.add(extractRandomCharacter(specials, random)));
+        IntStream.range(0, passwordLength - 3 * quarter)
+                .forEach(i -> charList.add(extractRandomCharacter(numbers, random)));
+
+        //섞은 다음 합치기
+        Collections.shuffle(charList);
+        return charList.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining());
+    }
+
+    private static char extractRandomCharacter(String sequence, SecureRandom random) {
+        return sequence.charAt(random.nextInt(sequence.length()));
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/service/utils/RedisUtil.java
+++ b/src/main/java/com/filmdoms/community/account/service/utils/RedisUtil.java
@@ -1,0 +1,22 @@
+package com.filmdoms.community.account.service.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String getData(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void setDataAndExpirationInMillis(String key, String value, long millis) {
+        redisTemplate.opsForValue().set(key, value, Duration.ofMillis(millis));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,19 @@ server:
 
 domain: ${DOMAIN}
 
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_ADDRESS}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 ---
 
 spring:
@@ -149,6 +162,10 @@ spring:
             client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
             scope: email
             redirect-uri: "{baseUrl}/front/oauth2/google"
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 cloud:
   aws:

--- a/src/test/java/com/filmdoms/community/account/service/EmailServiceTest.java
+++ b/src/test/java/com/filmdoms/community/account/service/EmailServiceTest.java
@@ -1,0 +1,60 @@
+package com.filmdoms.community.account.service;
+
+import com.filmdoms.community.account.data.dto.request.AuthCodeVerificationRequestDto;
+import com.filmdoms.community.account.data.dto.response.SimpleAccountResponseDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.service.utils.RedisUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+@SpringBootTest(classes = {EmailService.class})
+@ActiveProfiles("test")
+@DisplayName("이메일 서비스 테스트")
+class EmailServiceTest {
+
+    @Autowired
+    EmailService emailService;
+
+    @MockBean
+    RedisUtil redisUtil;
+
+    @MockBean
+    AccountRepository accountRepository;
+
+    @MockBean
+    AsyncEmailSendService asyncEmailSendService;
+
+    @Test
+    @DisplayName("인증 코드가 일치하면 오류가 발생하지 않고 응답 DTO를 반환함")
+    void verifyAuthCode() {
+        //given
+        String email = "address@domain.com";
+        String authCode = "sampleAuthCode";
+        String mockAccountUsername = "username";
+        Account mockAccount = Account.builder()
+                .username(mockAccountUsername)
+                .email(email)
+                .build();
+        ReflectionTestUtils.setField(mockAccount, Account.class, "id", 1L, Long.class);
+        Mockito.when(accountRepository.findByEmail(email)).thenReturn(Optional.ofNullable(mockAccount));
+        Mockito.when(redisUtil.getData(Mockito.any())).thenReturn(authCode);
+        AuthCodeVerificationRequestDto requestDto = new AuthCodeVerificationRequestDto(email, authCode);
+
+        //when
+        SimpleAccountResponseDto responseDto = emailService.verityAuthCode(requestDto);
+
+        //then
+        Assertions.assertThat(responseDto.getId()).isEqualTo(1L);
+        Assertions.assertThat(responseDto.getUsername()).isEqualTo(mockAccountUsername);
+    }
+}


### PR DESCRIPTION
이메일 인증/임시 비밀번호 발급 API를 구현했습니다.
API 명세 업데이트 완료했습니다.

### 언급 사항
* 비밀번호 찾기는 일단 임시 비밀번호 발급으로 구현했습니다. 이메일 계정에서 비밀번호 변경 페이지로 이동하는 방법도 생각해 봤는데, 이 경우에 프론트에서 화면을 하나 더 만들어야 하는 부담이 생길 것 같아 임시 비밀번호를 발급하고 로그인 후 변경하는 방향으로 구현해 봤습니다. 임시 비밀번호 발급의 경우 제3자가 임시 비밀번호 발급을 요청해서 비밀번호를 임시 비밀번호로 바꿀 수 있기 때문에, 이 부분에 대해서 상의를 해 보면 좋을 것 같습니다.

* 인증 코드를 발급하는 부분도 임시로 구현했습니다. 인증 코드 발송, 인증 코드 확인 API만 만들었는데, 나중에 코드를 수정할 때 프론트로 이메일과 인증 코드를 보내는 URL을 이메일에 삽입하면 좋을 것 같습니다. 즉 '이메일 링크를 통해 프론트 url로 이동(이때 이메일, 인증 코드를 같이 보냄) -> 프론트에서 백엔드 인증 코드 확인 url로 요청 -> 인증 코드 확인 응답 -> 프론트에서 인증 완료를 클라이언트에 알리거나 리다이렉트'와 같이 동작하게 하면 흐름이 자연스러울 듯 합니다.

* 이메일을 실제로 발송하는 부분은 비동기로 처리했습니다. 이메일 발송에 평균적으로 5초 이상 걸려서 클라이언트 대기 시간이 과도하게 길어지는 것을 방지하기 위함입니다. 응답이 바로 나가는 대신 이메일 발송 과정에서 예외가 발생했을 때도 이를 클라이언트 쪽에 전달할 수 없다는 단점이 있습니다. 일단 예외가 발생하면 로그를 찍도록 했습니다.

* 임시 비밀번호는 대소문자, 특수문자, 숫자를 섞은 길이가 10인 문자열을, 인증 코드는 그냥 UUID를 발급하도록 했는데, 이 부분은 임시로 정한 거라 나중에 바꿔도 무방합니다.

* 환경 변수 `GMAIL_ADDRESS`, `GMAIL_PASSWORD` 부분은 구글 앱 비밀번호를 발급받아 넣으시면 됩니다.