### PR TITLE
엔티티 생성 로직 보강

### DIFF
--- a/src/main/java/com/filmdoms/community/article/data/entity/extra/Critic.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/extra/Critic.java
@@ -1,5 +1,6 @@
 package com.filmdoms.community.article.data.entity.extra;
 
+import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.file.data.entity.File;
 import jakarta.persistence.*;
@@ -29,6 +30,9 @@ public class Critic {
 
     @Builder
     private Critic(Article article, File mainImage) {
+        if (article.getCategory() != Category.CRITIC || article.getTag().getCategory() != Category.CRITIC) {
+            throw new IllegalArgumentException("Wrong article category or tag");
+        }
         this.article = article;
         this.mainImage = mainImage;
     }

--- a/src/main/java/com/filmdoms/community/article/data/entity/extra/FilmUniverse.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/extra/FilmUniverse.java
@@ -1,5 +1,6 @@
 package com.filmdoms.community.article.data.entity.extra;
 
+import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.file.data.entity.File;
 import jakarta.persistence.*;
@@ -31,6 +32,9 @@ public class FilmUniverse {
 
     @Builder
     private FilmUniverse(Article article, File mainImage, LocalDateTime startDate, LocalDateTime endDate) {
+        if (article.getCategory() != Category.FILM_UNIVERSE || article.getTag().getCategory() != Category.FILM_UNIVERSE) {
+            throw new IllegalArgumentException("Wrong article category or tag");
+        }
         this.article = article;
         this.mainImage = mainImage;
         this.startDate = startDate;

--- a/src/test/java/com/filmdoms/community/article/data/entity/extra/CriticTest.java
+++ b/src/test/java/com/filmdoms/community/article/data/entity/extra/CriticTest.java
@@ -1,0 +1,74 @@
+package com.filmdoms.community.article.data.entity.extra;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.Tag;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.testentityprovider.TestAccountProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Critic 엔티티 테스트")
+class CriticTest {
+
+    @Test
+    @DisplayName("Article 카테고리가 잘못 설정되면 엔티티 생성자가 예외를 발생시킴")
+    void invalidCategory() {
+
+        //given
+        Account author = TestAccountProvider.get();
+        Article article = Article.builder()
+                .title("test title")
+                .content("test content")
+                .author(author)
+                .category(Category.MOVIE)
+                .tag(Tag.CRITIC_ACTOR)
+                .build();
+        Critic.CriticBuilder criticBuilder = Critic.builder()
+                .article(article);
+
+        //when & then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> criticBuilder.build());
+    }
+
+    @Test
+    @DisplayName("Article 태그가 잘못 설정되면 엔티티 생성자가 예외를 발생시킴")
+    void invalidTag() {
+
+        //given
+        Account author = TestAccountProvider.get();
+        Article article = Article.builder()
+                .title("test title")
+                .content("test content")
+                .author(author)
+                .category(Category.CRITIC)
+                .tag(Tag.OTT)
+                .build();
+        Critic.CriticBuilder criticBuilder = Critic.builder()
+                .article(article);
+
+        //when & then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> criticBuilder.build());
+    }
+
+    @Test
+    @DisplayName("Article 카테고리와 태그가 알맞게 설정되면 정상적으로 엔티티가 생성됨")
+    void validCategoryAndTag() {
+
+        //given
+        Account author = TestAccountProvider.get();
+        Article article = Article.builder()
+                .title("test title")
+                .content("test content")
+                .author(author)
+                .category(Category.CRITIC)
+                .tag(Tag.CRITIC_ACTOR)
+                .build();
+        Critic.CriticBuilder criticBuilder = Critic.builder()
+                .article(article);
+
+        //when & then
+        Critic critic = criticBuilder.build();
+    }
+}

--- a/src/test/java/com/filmdoms/community/article/data/entity/extra/FilmUniverseTest.java
+++ b/src/test/java/com/filmdoms/community/article/data/entity/extra/FilmUniverseTest.java
@@ -1,0 +1,82 @@
+package com.filmdoms.community.article.data.entity.extra;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.Tag;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.testentityprovider.TestAccountProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+@DisplayName("FilmUniverse 엔티티 테스트")
+class FilmUniverseTest {
+
+    @Test
+    @DisplayName("Article 카테고리가 잘못 설정되면 엔티티 생성자가 예외를 발생시킴")
+    void invalidCategory() {
+
+        //given
+        Account author = TestAccountProvider.get();
+        Article article = Article.builder()
+                .title("test title")
+                .content("test content")
+                .author(author)
+                .category(Category.MOVIE)
+                .tag(Tag.CLUB)
+                .build();
+        FilmUniverse.FilmUniverseBuilder filmUniverseBuilder = FilmUniverse.builder()
+                .article(article)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now());
+
+        //when & then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> filmUniverseBuilder.build());
+    }
+
+    @Test
+    @DisplayName("Article 태그가 잘못 설정되면 엔티티 생성자가 예외를 발생시킴")
+    void invalidTag() {
+
+        //given
+        Account author = TestAccountProvider.get();
+        Article article = Article.builder()
+                .title("test title")
+                .content("test content")
+                .author(author)
+                .category(Category.FILM_UNIVERSE)
+                .tag(Tag.OTT)
+                .build();
+        FilmUniverse.FilmUniverseBuilder filmUniverseBuilder = FilmUniverse.builder()
+                .article(article)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now());
+
+        //when & then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> filmUniverseBuilder.build());
+    }
+
+    @Test
+    @DisplayName("Article 카테고리와 태그가 알맞게 설정되면 정상적으로 엔티티가 생성됨")
+    void validCategoryAndTag() {
+
+        //given
+        Account author = TestAccountProvider.get();
+        Article article = Article.builder()
+                .title("test title")
+                .content("test content")
+                .author(author)
+                .category(Category.FILM_UNIVERSE)
+                .tag(Tag.CLUB)
+                .build();
+        FilmUniverse.FilmUniverseBuilder filmUniverseBuilder = FilmUniverse.builder()
+                .article(article)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now());
+
+        //when & then
+        FilmUniverse filmUniverse = filmUniverseBuilder.build();
+    }
+}

--- a/src/test/java/com/filmdoms/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/filmdoms/community/comment/service/CommentServiceTest.java
@@ -17,12 +17,15 @@ import com.filmdoms.community.comment.data.entity.CommentVote;
 import com.filmdoms.community.comment.data.entity.CommentVoteKey;
 import com.filmdoms.community.comment.repository.CommentRepository;
 import com.filmdoms.community.comment.repository.CommentVoteRepository;
+import com.filmdoms.community.testentityprovider.TestAccountProvider;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,9 +56,11 @@ class CommentServiceTest {
     @DisplayName("부모 댓글 생성이 정상적으로 이루어지는지 확인")
     void createParentComment() {
         //given
-        Account articleAuthor = createSampleAccount("articleAuthor");
+        Account articleAuthor = TestAccountProvider.get();
+        Account commentAuthor = TestAccountProvider.get();
+        accountRepository.saveAll(List.of(articleAuthor, commentAuthor));
+
         Article article = createSampleArticle(articleAuthor);
-        Account commentAuthor = createSampleAccount("commentAuthor");
         CommentCreateRequestDto requestDto = new CommentCreateRequestDto(article.getId(), null, "content", false);
 
         //when
@@ -73,10 +78,12 @@ class CommentServiceTest {
     @DisplayName("자식 댓글 생성이 정상적으로 이루어지는지 확인")
     void createChildComment() {
         //given
-        Account articleAuthor = createSampleAccount("articleAuthor");
+        Account articleAuthor = TestAccountProvider.get();
+        Account parentCommentAuthor = TestAccountProvider.get();
+        Account childCommentAuthor = TestAccountProvider.get();
+        accountRepository.saveAll(List.of(articleAuthor, parentCommentAuthor, childCommentAuthor));
+
         Article article = createSampleArticle(articleAuthor);
-        Account parentCommentAuthor = createSampleAccount("parentCommentAuthor");
-        Account childCommentAuthor = createSampleAccount("childCommentAuthor");
         Comment parentComment = createSampleComment(article, parentCommentAuthor, null);
         CommentCreateRequestDto requestDto = new CommentCreateRequestDto(article.getId(), parentComment.getId(), "content", false);
 
@@ -94,9 +101,11 @@ class CommentServiceTest {
     @Test
     @DisplayName("댓글 수정이 정상적으로 이루어지는지 확인")
     void updateComment() {
-        Account articleAuthor = createSampleAccount("articleAuthor");
+        Account articleAuthor = TestAccountProvider.get();
+        Account commentAuthor = TestAccountProvider.get();
+        accountRepository.saveAll(List.of(articleAuthor, commentAuthor));
+
         Article article = createSampleArticle(articleAuthor);
-        Account commentAuthor = createSampleAccount("commentAuthor");
         Comment comment = createSampleComment(article, commentAuthor, null);
         CommentUpdateRequestDto requestDto = new CommentUpdateRequestDto("updatedContent");
 
@@ -111,9 +120,11 @@ class CommentServiceTest {
     @Test
     @DisplayName("자식 댓글이 없는 부모 댓글 삭제가 정상적으로 이루어지는지 확인")
     void deleteComment() {
-        Account articleAuthor = createSampleAccount("articleAuthor");
+        Account articleAuthor = TestAccountProvider.get();
+        Account commentAuthor = TestAccountProvider.get();
+        accountRepository.saveAll(List.of(articleAuthor, commentAuthor));
+
         Article article = createSampleArticle(articleAuthor);
-        Account commentAuthor = createSampleAccount("commentAuthor");
         Comment comment = createSampleComment(article, commentAuthor, null);
 
         //when
@@ -126,9 +137,11 @@ class CommentServiceTest {
     @Test
     @DisplayName("추천 안한 댓글을 추천하면 추천수가 정상적으로 증가하는지 확인")
     void applyVoteComment() {
-        Account articleAuthor = createSampleAccount("articleAuthor");
+        Account articleAuthor = TestAccountProvider.get();
+        Account commentAuthor = TestAccountProvider.get();
+        accountRepository.saveAll(List.of(articleAuthor, commentAuthor));
+
         Article article = createSampleArticle(articleAuthor);
-        Account commentAuthor = createSampleAccount("commentAuthor");
         Comment comment = createSampleComment(article, commentAuthor, null);
 
         //when
@@ -143,9 +156,11 @@ class CommentServiceTest {
     @Test
     @DisplayName("추천한 댓글을 추천하면 추천수가 정상적으로 감소하는지 확인")
     void cancelVoteComment() {
-        Account articleAuthor = createSampleAccount("articleAuthor");
+        Account articleAuthor = TestAccountProvider.get();
+        Account commentAuthor = TestAccountProvider.get();
+        accountRepository.saveAll(List.of(articleAuthor, commentAuthor));
+
         Article article = createSampleArticle(articleAuthor);
-        Account commentAuthor = createSampleAccount("commentAuthor");
         Comment comment = createSampleComment(article, commentAuthor, null);
         createSampleVote(articleAuthor, comment);
 
@@ -156,13 +171,6 @@ class CommentServiceTest {
         assertThat(responseDto)
                 .hasFieldOrPropertyWithValue("isVoted", false)
                 .hasFieldOrPropertyWithValue("voteCount", 0);
-    }
-
-    private Account createSampleAccount(String username) {
-        Account account = Account.builder()
-                .username(username)
-                .build();
-        return accountRepository.save(account);
     }
 
     private Article createSampleArticle(Account author) {

--- a/src/test/java/com/filmdoms/community/testentityprovider/TestAccountProvider.java
+++ b/src/test/java/com/filmdoms/community/testentityprovider/TestAccountProvider.java
@@ -1,0 +1,20 @@
+package com.filmdoms.community.testentityprovider;
+
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+
+public class TestAccountProvider {
+
+    public static int count;
+
+    public static Account get() {
+        count++;
+        Account account = Account.builder()
+                .nickname("test_nickname_" + count)
+                .email("test_email" + count + "@filmdoms.com")
+                .password("test_password")
+                .role(AccountRole.USER)
+                .build();
+        return account;
+    }
+}


### PR DESCRIPTION
* 현재 FilmUniverse, Critic 엔티티 생성 시 카테고리, 태그를 자체 검증할 수 있는 로직이 없어 생성자 내부에 로직을 추가했습니다.
    * 영화 게시판 게시물의 경우 Article 엔티티를 그대로 사용했기 때문에 따로 메서드를 만들지 않는 한 카테고리/태그를 검증할 방법이 없는 것 같아 그대로 두었습니다.
 * 테스트 시 Account 생성 로직의 반복이 많아 이 부분을 따로 관리하는 클래스를 만들었습니다.
