### PR TITLE
배너를 관리하는 임시 관리자 생성, 배너 반환 갯수 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -1,32 +1,23 @@
 package com.filmdoms.community.account.controller;
 
+import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
-import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
-import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
-import com.filmdoms.community.account.data.dto.request.LoginRequestDto;
-import com.filmdoms.community.account.data.dto.request.UpdatePasswordRequestDto;
-import com.filmdoms.community.account.data.dto.request.UpdateProfileRequestDto;
-import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
-import com.filmdoms.community.account.data.dto.response.CheckDuplicateResponseDto;
-import com.filmdoms.community.account.data.dto.response.LoginResponseDto;
-import com.filmdoms.community.account.data.dto.response.RefreshAccessTokenResponseDto;
-import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.account.data.dto.request.*;
+import com.filmdoms.community.account.data.dto.response.*;
+import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.service.AccountService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/account")
@@ -34,7 +25,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
     private final AccountService accountService;
+    private final PasswordEncoder passwordEncoder;
+    private final AccountRepository accountRepository;
+    @Value("${admin-password}")
+    private String password;
 
+    @GetMapping("/temp/admin")
+    public Response generateAdmin() {
+        Account account = Account.builder()
+                .nickname("admin")
+                .password(passwordEncoder.encode(password))
+                .role(AccountRole.ADMIN)
+                .email("testadmin@naver.com")
+                .build();
+        accountRepository.save(account);
+        return Response.success();
+    }
 
     @PostMapping("/login")
     public Response<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto) {

--- a/src/main/java/com/filmdoms/community/banner/repository/BannerRepository.java
+++ b/src/main/java/com/filmdoms/community/banner/repository/BannerRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
-    List<Banner> findAllByOrderByIdDesc();
+    List<Banner> findTop5ByOrderByIdDesc();
 
     @Query("SELECT b FROM Banner b " +
             "LEFT JOIN FETCH b.file " +

--- a/src/main/java/com/filmdoms/community/banner/service/BannerService.java
+++ b/src/main/java/com/filmdoms/community/banner/service/BannerService.java
@@ -29,7 +29,7 @@ public class BannerService {
 
     @Transactional(readOnly = true)
     public List<BannerResponseDto> getMainPageBanner() {
-        return bannerRepository.findAllByOrderByIdDesc()
+        return bannerRepository.findTop5ByOrderByIdDesc()
                 .stream()
                 .map(BannerResponseDto::from)
                 .toList();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ server:
       enabled: false
 
 domain: ${DOMAIN}
-
+admin-password: ${ADMIN}
 # 어플리케이션 실행 시 LocalVariableTableParameterNameDiscoverer가 WARN 로그를 출력하지 않도록 함
 logging:
   level:


### PR DESCRIPTION
현재 코드에서 배너를 관리하는 임시 관리자를 생성하는 코드를 추가했습니다.(배너 등록시 admin임을 확인함)
/temp/admin 으로 get요청시 임시 관리자가 생성됩니다.(생성된 암호는 환경변수를 사용합니다)
같은 작업을 두 번 이상 하게 되면, 어차피 Save가 들어가지 않았어서 이렇게 임시로 구현해도 문제 없어 보입니다.

배너 반환이 Find All 이었는데, 메인페이지의 배너는 최신 5개까지 들어가기 때문에 5개로 제한해도 문제 없어보여서 해당 코드 수정했습니다.

