### PR TITLE
관심 영화 구현

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/dto/request/JoinRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/JoinRequestDto.java
@@ -1,5 +1,7 @@
 package com.filmdoms.community.account.data.dto.request;
 
+import static com.filmdoms.community.account.exception.ValidationMessage.LIST_TOO_BIG;
+import static com.filmdoms.community.account.exception.ValidationMessage.CANNOT_BE_NULL;
 import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_EMAIL;
 import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_NICKNAME;
 import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_PASSWORD;
@@ -7,7 +9,10 @@ import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCH
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,13 +27,20 @@ public class JoinRequestDto {
 //    @Pattern(regexp = "/^[a-z0-9_]{8,20}$/", message = UNMATCHED_USERNAME)
 //    private String username;
 
+    @NotNull(message = "이메일은 " + CANNOT_BE_NULL)
     @Email(message = UNMATCHED_EMAIL)
     private String email;
 
+    @NotNull(message = "비밀번호는 " + CANNOT_BE_NULL)
     @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,100}", message = UNMATCHED_PASSWORD)
     private String password;
 
+    @NotNull(message = "닉네임은 " + CANNOT_BE_NULL)
     @Min(value = 2, message = UNMATCHED_NICKNAME)
     @Max(value = 20, message = UNMATCHED_NICKNAME)
     private String nickname;
+
+    @NotNull(message = "관심 영화는 " + CANNOT_BE_NULL)
+    @Size(max = 5, message = "관심 영화 " + LIST_TOO_BIG)
+    private List<String> favoriteMovies;
 }

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/UpdateProfileRequestDto.java
@@ -1,11 +1,14 @@
 package com.filmdoms.community.account.data.dto.request;
 
 import static com.filmdoms.community.account.exception.ValidationMessage.IMAGE_REQUIRED;
+import static com.filmdoms.community.account.exception.ValidationMessage.LIST_TOO_BIG;
 import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_NICKNAME;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +26,7 @@ public class UpdateProfileRequestDto {
     @Min(value = 2, message = UNMATCHED_NICKNAME)
     @Max(value = 20, message = UNMATCHED_NICKNAME)
     private String nickname;
+
+    @Size(max = 5, message = "좋아하는 영화 " + LIST_TOO_BIG)
+    private List<String> favoriteMovies;
 }

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/AccountResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/AccountResponseDto.java
@@ -3,7 +3,11 @@ package com.filmdoms.community.account.data.dto.response;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.constant.AccountStatus;
 import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.data.entity.Movie;
+import com.filmdoms.community.account.data.entity.FavoriteMovie;
 import com.filmdoms.community.file.data.dto.response.FileResponseDto;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +24,9 @@ public class AccountResponseDto {
     private boolean isSocialLogin;
     private FileResponseDto profileImage;
 
-    private AccountResponseDto(Account account) {
+    private List<String> favoriteMovies;
+
+    private AccountResponseDto(Account account, List<FavoriteMovie> favoriteMovies) {
         this.id = account.getId();
         this.nickname = account.getNickname();
         this.email = account.getEmail();
@@ -28,9 +34,13 @@ public class AccountResponseDto {
         this.accountStatus = account.getAccountStatus();
         this.isSocialLogin = account.isSocialLogin();
         this.profileImage = FileResponseDto.from(account.getProfileImage());
+        this.favoriteMovies = favoriteMovies.stream()
+                .map(FavoriteMovie::getMovie)
+                .map(Movie::getName)
+                .collect(Collectors.toList());
     }
 
-    public static AccountResponseDto from(Account account) {
-        return new AccountResponseDto(account);
+    public static AccountResponseDto from(Account account, List<FavoriteMovie> favoriteMovies) {
+        return new AccountResponseDto(account, favoriteMovies);
     }
 }

--- a/src/main/java/com/filmdoms/community/account/data/entity/FavoriteMovie.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/FavoriteMovie.java
@@ -1,0 +1,61 @@
+package com.filmdoms.community.account.data.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "favorite_movie", indexes = {
+        @Index(columnList = "account_id"),
+        @Index(columnList = "movie_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteMovie {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @ManyToOne
+    @JoinColumn(name = "movie_id")
+    private Movie movie;
+
+    @Builder
+    private FavoriteMovie(Account account, Movie movie) {
+        this.account = account;
+        this.movie = movie;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FavoriteMovie that = (FavoriteMovie) o;
+        return Objects.equals(account, that.account) && Objects.equals(movie,
+                that.movie);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(account, movie);
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/data/entity/Movie.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Movie.java
@@ -1,0 +1,29 @@
+package com.filmdoms.community.account.data.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "movie")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Movie {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", unique = true)
+    private String name;
+
+    public Movie(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/exception/ValidationMessage.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ValidationMessage.java
@@ -2,6 +2,7 @@ package com.filmdoms.community.account.exception;
 
 public class ValidationMessage {
 
+    public static final String CANNOT_BE_NULL = "필수로 입력되어야 합니다.";
     public static final String TITLE_NOT_BLANK = "제목은 공백일 수 없습니다.";
     public static final String TITLE_SIZE = "제목은 100자 이내이어야 합니다.";
     public static final String CONTENT_NOT_BLANK = "본문은 공백일 수 없습니다.";
@@ -11,5 +12,6 @@ public class ValidationMessage {
     public static final String UNMATCHED_PASSWORD = "비밀번호는 8자 이상, 100자 이하의 대문자, 소문자, 숫자, 및 특수문자의 조합이어야 합니다.";
     public static final String UNMATCHED_EMAIL = "형식에 맞는 이메일 주소여야 합니다.";
     public static final String UNMATCHED_NICKNAME = "닉네임은 2자 이상, 20자 이하이어야 합니다.";
+    public static final String LIST_TOO_BIG = "개수가 너무 많습니다.";
 
 }

--- a/src/main/java/com/filmdoms/community/account/repository/FavoriteMovieRepository.java
+++ b/src/main/java/com/filmdoms/community/account/repository/FavoriteMovieRepository.java
@@ -1,0 +1,17 @@
+package com.filmdoms.community.account.repository;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.data.entity.FavoriteMovie;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FavoriteMovieRepository extends JpaRepository<FavoriteMovie, Long> {
+
+    @Query("SELECT m FROM FavoriteMovie m " +
+            "JOIN FETCH m.account " +
+            "JOIN FETCH m.movie " +
+            "WHERE m.account = :account")
+    List<FavoriteMovie> findAllByAccount(@Param("account") Account account);
+}

--- a/src/main/java/com/filmdoms/community/account/repository/MovieRepository.java
+++ b/src/main/java/com/filmdoms/community/account/repository/MovieRepository.java
@@ -1,0 +1,13 @@
+package com.filmdoms.community.account.repository;
+
+import com.filmdoms.community.account.data.entity.Movie;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MovieRepository extends JpaRepository<Movie, Long> {
+
+    @Query("SELECT m FROM Movie m WHERE m.name IN :names")
+    List<Movie> findAllByNames(@Param("names") List<String> names);
+}


### PR DESCRIPTION
관심 영화 설정은 기존의 회원가입과 프로필 조회 및 수정 기능에 추가된 기능입니다.
현재 영화와 관련된 DB가 존재하지 않으므로, 단순 입력 받은대로 저장하고, 돌려주는 방식으로 구현되어있습니다. 

### 참고 사항:
* 유저가 관심 영화로 설정할 수 있는 영화도 여러 개이고, 한 영화를 관심 영화 설정할 수 있는 유저도 여럿이므로, 유저와 영화의 관계는 다대다 입니다. 따라서 유저와 영화 사이의 관심영화(`FavoriteMovie`) 테이블을 엔티티로 승격해, 유저와 영화 둘 모두에 다대일 매핑을 해 주었습니다.
 