### PR TITLE
Critic페이지 요청시 반환 데이터에 mainImage 추가

### DIFF
--- a/src/main/java/com/filmdoms/community/article/data/dto/response/boardlist/CriticListResponseResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/boardlist/CriticListResponseResponseDto.java
@@ -1,13 +1,22 @@
 package com.filmdoms.community.article.data.dto.response.boardlist;
 
 import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.data.entity.extra.Critic;
+import com.filmdoms.community.file.data.entity.File;
+import lombok.Getter;
 
+@Getter
 public class CriticListResponseResponseDto extends ParentBoardListResponseDto {
-    public CriticListResponseResponseDto(Article article) {
+
+    String mainImage;
+
+    public CriticListResponseResponseDto(Article article, File mainImage) {
         super(article);
+        this.mainImage = mainImage.getUuidFileName();
+
     }
 
-    public static CriticListResponseResponseDto from(Article article) {
-        return new CriticListResponseResponseDto(article);
+    public static CriticListResponseResponseDto from(Critic critic) {
+        return new CriticListResponseResponseDto(critic.getArticle(), critic.getMainImage());
     }
 }

--- a/src/main/java/com/filmdoms/community/article/repository/CriticRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/CriticRepository.java
@@ -1,10 +1,13 @@
 package com.filmdoms.community.article.repository;
 
 
+import com.filmdoms.community.article.data.constant.Tag;
 import com.filmdoms.community.article.data.entity.extra.Critic;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +22,22 @@ public interface CriticRepository extends JpaRepository<Critic, Long> {
     List<Critic> findAllWithArticleAuthorMainImageContent(Pageable pageable);
 
     Optional<Critic> findByArticleId(Long articleId);
+
+    @Query(value = "SELECT c FROM Critic c " +
+            "LEFT JOIN FETCH c.article " +
+            "LEFT JOIN FETCH c.article.author " +
+            "LEFT JOIN FETCH c.mainImage " +
+            "LEFT JOIN FETCH c.article.content"
+            , countQuery = "select count(c) from Critic c")
+    Page<Critic> getCritics(Pageable pageable);
+
+    @Query(value = "SELECT c FROM Critic c " +
+            "LEFT JOIN FETCH c.article " +
+            "LEFT JOIN FETCH c.article.author " +
+            "LEFT JOIN FETCH c.mainImage " +
+            "LEFT JOIN FETCH c.article.content where c.article.tag =:tagId"
+            , countQuery = "SELECT count(c) from Critic c inner join c.article where c.article.tag =:tagId")
+    Page<Critic> getCriticsByTag(@Param("tagId") Tag tag, Pageable pageable);
+
+
 }

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -32,7 +32,6 @@ import com.filmdoms.community.file.repository.FileRepository;
 import com.filmdoms.community.vote.data.entity.VoteKey;
 import com.filmdoms.community.vote.repository.VoteRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -46,7 +45,6 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
-@Slf4j
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
@@ -236,8 +234,6 @@ public class ArticleService {
                 articles = articleRepository.findArticlesByKeyword(category, keyword, pageable);
                 Page<MovieListResponseResponseDto> movieListResponseDtos = articles.map(MovieListResponseResponseDto::from);
                 return movieListResponseDtos;
-            case CRITIC:
-
             case FILM_UNIVERSE:
                 articles = articleRepository.findArticlesByKeyword(category, keyword, pageable);
                 Page<FilmUniverseListResponseResponseDto> filmUniverseDto = articles.map(FilmUniverseListResponseResponseDto::from);

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -27,13 +27,12 @@ import com.filmdoms.community.article.repository.AnnounceRepository;
 import com.filmdoms.community.article.repository.ArticleRepository;
 import com.filmdoms.community.article.repository.CriticRepository;
 import com.filmdoms.community.article.repository.FilmUniverseRepository;
-import com.filmdoms.community.comment.repository.CommentRepository;
 import com.filmdoms.community.file.data.entity.File;
 import com.filmdoms.community.file.repository.FileRepository;
-import com.filmdoms.community.file.service.ImageFileService;
 import com.filmdoms.community.vote.data.entity.VoteKey;
 import com.filmdoms.community.vote.repository.VoteRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -47,6 +46,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
@@ -178,7 +178,7 @@ public class ArticleService {
 
 
         Page<Article> articlesByCategory;
-
+        Page<Critic> critics;
         switch (category) {
             case MOVIE:
                 if (tag != null)
@@ -189,12 +189,11 @@ public class ArticleService {
                 return movieListDtos;
             case CRITIC:
                 if (tag != null)
-                    articlesByCategory = articleRepository.findArticlesByCategoryAndTag(category, tag, pageable);
+                    critics = criticRepository.getCriticsByTag(tag, pageable);
                 else
-                    articlesByCategory = articleRepository.findArticlesByCategory(category, pageable);
-                Page<CriticListResponseResponseDto> criticListDtos = articlesByCategory.map(
-                        CriticListResponseResponseDto::from);
-                return criticListDtos;
+                    critics = criticRepository.getCritics(pageable);
+                Page<CriticListResponseResponseDto> criticDtos = critics.map(CriticListResponseResponseDto::from);
+                return criticDtos;
             case FILM_UNIVERSE:
                 if (tag != null)
                     articlesByCategory = articleRepository.findArticlesByCategoryAndTag(category, tag, pageable);
@@ -238,8 +237,6 @@ public class ArticleService {
                 Page<MovieListResponseResponseDto> movieListResponseDtos = articles.map(MovieListResponseResponseDto::from);
                 return movieListResponseDtos;
             case CRITIC:
-                articles = articleRepository.findArticlesByKeyword(category, keyword, pageable);
-                Page<CriticListResponseResponseDto> criticListResponseDto = articles.map(CriticListResponseResponseDto::from);
 
             case FILM_UNIVERSE:
                 articles = articleRepository.findArticlesByKeyword(category, keyword, pageable);
@@ -257,10 +254,6 @@ public class ArticleService {
                 articles = articleRepository.findArticlesByNickname(category, authorName, pageable);
                 Page<MovieListResponseResponseDto> movieListResponseDtos = articles.map(MovieListResponseResponseDto::from);
                 return movieListResponseDtos;
-            case CRITIC:
-                articles = articleRepository.findArticlesByNickname(category, authorName, pageable);
-                Page<CriticListResponseResponseDto> criticListResponseDto = articles.map(CriticListResponseResponseDto::from);
-
             case FILM_UNIVERSE:
                 articles = articleRepository.findArticlesByNickname(category, authorName, pageable);
                 Page<FilmUniverseListResponseResponseDto> filmUniverseDto = articles.map(FilmUniverseListResponseResponseDto::from);

--- a/src/main/java/com/filmdoms/community/article/service/InitService2.java
+++ b/src/main/java/com/filmdoms/community/article/service/InitService2.java
@@ -58,22 +58,27 @@ public class InitService2 {
                 .toList();
 
         //critic 게시판 생성
+        File criticFile = initServiceGenerator.fileGenerator("a1d55b8b-ee40-42b0-8b4f-d18a3c5dd7a0.png", "criticFileName");
         for (int i = 0; i < 20; i++) {
             for (Tag tag : criticTagList) {
-                initServiceGenerator.articleGenerator("테스트 티이틀" + i + "번째",
+                Article article = initServiceGenerator.articleGenerator("테스트 티이틀" + i + "번째",
                         Category.CRITIC, tag, testAccount, false, "비평게시물" + i + "번째 태그 :" + tag + "내용");
+                initServiceGenerator.criticGenerator(article, criticFile);
             }
             for (Tag tag : criticTagList) {
-                initServiceGenerator.articleGenerator("테스트 티이틀 이미지있음" + i + "번째",
+                Article article = initServiceGenerator.articleGenerator("테스트 티이틀 이미지있음" + i + "번째",
                         Category.CRITIC, tag, testAccount, true, "비평게시물" + i + "번째 태그 :" + tag + "내용에 이미지 있음");
+                initServiceGenerator.criticGenerator(article, criticFile);
             }
             for (Tag tag : criticTagList) {
-                initServiceGenerator.articleGenerator("테스트 티이틀" + i + "번째",
+                Article article = initServiceGenerator.articleGenerator("테스트 티이틀" + i + "번째",
                         Category.CRITIC, tag, testAccount2, false, "비평게시물" + i + "번째 태그 :" + tag + "내용");
+                initServiceGenerator.criticGenerator(article, criticFile);
             }
             for (Tag tag : criticTagList) {
-                initServiceGenerator.articleGenerator("테스트 티이틀 이미지있음" + i + "번째",
+                Article article = initServiceGenerator.articleGenerator("테스트 티이틀 이미지있음" + i + "번째",
                         Category.CRITIC, tag, testAccount2, true, "비평게시물" + i + "번째 태그 :" + tag + "내용에 이미지 있음");
+                initServiceGenerator.criticGenerator(article, criticFile);
             }
         }
         List<Tag> filmUniverseTagList = Arrays.stream(Tag.values()) //게시판 태그만 추출

--- a/src/main/java/com/filmdoms/community/article/service/InitServiceGenerator.java
+++ b/src/main/java/com/filmdoms/community/article/service/InitServiceGenerator.java
@@ -7,14 +7,16 @@ import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.constant.Tag;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.article.data.entity.extra.Announce;
+import com.filmdoms.community.article.data.entity.extra.Critic;
 import com.filmdoms.community.article.data.entity.extra.FilmUniverse;
 import com.filmdoms.community.article.repository.AnnounceRepository;
 import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.article.repository.CriticRepository;
 import com.filmdoms.community.article.repository.FilmUniverseRepository;
-import com.filmdoms.community.file.data.entity.File;
-import com.filmdoms.community.file.repository.FileRepository;
 import com.filmdoms.community.comment.data.entity.Comment;
 import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.file.data.entity.File;
+import com.filmdoms.community.file.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +34,7 @@ public class InitServiceGenerator {
     private final FilmUniverseRepository filmUniverseRepository;
     private final AnnounceRepository announceRepository;
     private final ArticleRepository articleRepository;
+    private final CriticRepository criticRepository;
 
     public File fileGenerator(String uuidFileName, String originalFileName) {
         File fileImage = File.builder() //게시글과 매핑될 디폴트 이미지 생성
@@ -96,6 +99,17 @@ public class InitServiceGenerator {
                 .build();
         filmUniverseRepository.save(filmUniverse);
         return filmUniverse;
+    }
+
+    public Critic criticGenerator(Article article, File mainImage) {
+
+        Critic critic = Critic.builder()
+                .article(article)
+                .mainImage(mainImage)
+                .build();
+        criticRepository.save(critic);
+        return critic;
+
     }
 
     public Announce announceGenerator(Article article) {


### PR DESCRIPTION
기존에 Critic 페이지 시안이 나오지 않았어서, 임의로 Article 로 사용했었는데
Critic 페이지 시안이 나오게 되면서 mainImage(썸네일 이미지) 가 응답 데이터에 없음을 확인하였고 
해당 부분 추가 진행했습니다.

원래는 File를 내보냈으나, uuid만 알면 nginx에서 /image로 가져올 수 있기 때문에, uuid 이름만 내보내도 문제가 없다는 생각이 들었습니다.