### PR TITLE
리프레시 토큰 httponly 쿠키로 발급하도록 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
@@ -14,6 +14,7 @@ import java.security.Key;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -59,6 +60,16 @@ public class JwtTokenProvider {
                 .setIssuedAt(new Date())
                 .signWith(getKey(), SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public ResponseCookie createRefreshTokenCookie (String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(false) // TODO: 실서비스시엔 true 로 변경해야 함.
+                .maxAge(TOKEN_VALID_MILLISECOND)
+                .sameSite("None")
+                .path("/api")
+                .build();
     }
 
     // 토큰 인증 정보 조회

--- a/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
@@ -30,6 +30,7 @@ public class JwtTokenProvider {
     private String secretKey;
     private byte[] keyBytes;
     private final long TOKEN_VALID_MILLISECOND = 1000L * 60 * 60;
+    private final long REFRESH_VALID_SECOND = 60L * 60 * 24 * 30;
 
     @PostConstruct // Bean 으로 주입되면서 실행
     private void init() {
@@ -66,7 +67,7 @@ public class JwtTokenProvider {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .maxAge(TOKEN_VALID_MILLISECOND)
+                .maxAge(REFRESH_VALID_SECOND) // 초 단위
                 .sameSite("None")
                 .path("/api")
                 .build();

--- a/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/filmdoms/community/account/config/jwt/JwtTokenProvider.java
@@ -65,7 +65,7 @@ public class JwtTokenProvider {
     public ResponseCookie createRefreshTokenCookie (String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(false) // TODO: 실서비스시엔 true 로 변경해야 함.
+                .secure(true)
                 .maxAge(TOKEN_VALID_MILLISECOND)
                 .sameSite("None")
                 .path("/api")

--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -69,16 +69,12 @@ public class AccountController {
     }
 
     @PostMapping("/refresh-token")
-    public Response<AccessTokenResponseDto> refreshAccessToken(@RequestHeader("Cookie") String cookieHeader) {
-        String refreshToken = extractRefreshToken(cookieHeader)
-                .orElseThrow(() -> new ApplicationException(ErrorCode.TOKEN_NOT_FOUND));
+    public Response<AccessTokenResponseDto> refreshAccessToken(@CookieValue("refreshToken") String refreshToken) {
         return Response.success(accountService.refreshAccessToken(refreshToken));
     }
 
     @PostMapping("/logout")
-    public Response<Void> logout(@RequestHeader("Cookie") String cookieHeader) {
-        String refreshToken = extractRefreshToken(cookieHeader)
-                .orElseThrow(() -> new ApplicationException(ErrorCode.TOKEN_NOT_FOUND));
+    public Response<Void> logout(@CookieValue("refreshToken") String refreshToken) {
         accountService.logout(refreshToken);
         return Response.success();
     }

--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -1,7 +1,9 @@
 package com.filmdoms.community.account.controller;
 
+import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.LoginDto;
 import com.filmdoms.community.account.data.dto.request.*;
 import com.filmdoms.community.account.data.dto.response.*;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileArticleResponseDto;
@@ -12,17 +14,19 @@ import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.service.AccountService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -33,6 +37,7 @@ public class AccountController {
     private final AccountService accountService;
     private final PasswordEncoder passwordEncoder;
     private final AccountRepository accountRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     @Value("${admin-password}")
     private String password;
 
@@ -49,28 +54,30 @@ public class AccountController {
     }
 
     @PostMapping("/login")
-    public Response<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto) {
-        return Response.success(accountService.login(requestDto.getEmail(), requestDto.getPassword()));
+    public Response<AccessTokenResponseDto> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
+        LoginDto dto = accountService.login(requestDto.getEmail(), requestDto.getPassword());
+        ResponseCookie cookie = jwtTokenProvider.createRefreshTokenCookie(dto.getRefreshToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return Response.success(AccessTokenResponseDto.from(dto));
     }
 
-    private Optional<String> extractToken(HttpServletRequest request) {
-        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            return Optional.of(authHeader.substring(7));
-        }
-        return Optional.empty();
+    private Optional<String> extractRefreshToken(String cookieHeader) {
+        return Optional.ofNullable(cookieHeader).flatMap(header -> Arrays.stream(header.split("; "))
+                .filter(cookie -> cookie.startsWith("refreshToken="))
+                .findFirst()
+                .map(cookie -> cookie.substring("refreshToken=".length())));
     }
 
     @PostMapping("/refresh-token")
-    public Response<RefreshAccessTokenResponseDto> refreshAccessToken(HttpServletRequest request) {
-        String refreshToken = extractToken(request)
+    public Response<AccessTokenResponseDto> refreshAccessToken(@RequestHeader("Cookie") String cookieHeader) {
+        String refreshToken = extractRefreshToken(cookieHeader)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.TOKEN_NOT_FOUND));
         return Response.success(accountService.refreshAccessToken(refreshToken));
     }
 
     @PostMapping("/logout")
-    public Response<Void> logout(HttpServletRequest request) {
-        String refreshToken = extractToken(request)
+    public Response<Void> logout(@RequestHeader("Cookie") String cookieHeader) {
+        String refreshToken = extractRefreshToken(cookieHeader)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.TOKEN_NOT_FOUND));
         accountService.logout(refreshToken);
         return Response.success();

--- a/src/main/java/com/filmdoms/community/account/data/dto/LoginDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/LoginDto.java
@@ -1,4 +1,4 @@
-package com.filmdoms.community.account.data.dto.response;
+package com.filmdoms.community.account.data.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Builder
-public class RefreshAccessTokenResponseDto {
-
+public class LoginDto {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/AccessTokenResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/AccessTokenResponseDto.java
@@ -1,0 +1,22 @@
+package com.filmdoms.community.account.data.dto.response;
+
+import com.filmdoms.community.account.data.dto.LoginDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class AccessTokenResponseDto {
+
+    private String accessToken;
+
+    public static AccessTokenResponseDto from(LoginDto dto) {
+        return AccessTokenResponseDto.builder()
+                .accessToken(dto.getAccessToken())
+                .build();
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "해당 유저는 요청을 수행할 권한이 없습니다."),
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류가 발생했습니다."),
     AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
-    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "헤더에 토큰이 존재하지 않습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "토큰이 첨부되지 않았습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     TOKEN_NOT_IN_DB(HttpStatus.NOT_FOUND, "저장된 리프레시 토큰을 찾지 못했습니다. 만료되었거나, 액세스 토큰을 잘못 보내지 않았는지 확인해주세요."),
     URI_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI가 존재하지 않습니다."),

--- a/src/main/java/com/filmdoms/community/account/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/filmdoms/community/account/exception/GlobalControllerAdvice.java
@@ -1,16 +1,14 @@
 package com.filmdoms.community.account.exception;
 
 import com.filmdoms.community.account.data.dto.response.Response;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -51,6 +49,14 @@ public class GlobalControllerAdvice {
                 .collect(Collectors.toList());
         return ResponseEntity.status(ErrorCode.REQUEST_PARSE_ERROR.getStatus())
                 .body(Response.error(ErrorCode.REQUEST_PARSE_ERROR.name(), errors));
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<?> cookieExceptionHandler(
+            MissingRequestCookieException e) {
+        log.error("Error occurs: {}", e.toString());
+        return ResponseEntity.status(ErrorCode.TOKEN_NOT_FOUND.getStatus())
+                .body(Response.error(ErrorCode.TOKEN_NOT_FOUND.name(), ErrorCode.TOKEN_NOT_FOUND.getMessage()));
     }
 }
 

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -3,13 +3,14 @@ package com.filmdoms.community.account.service;
 import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.LoginDto;
 import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
 import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
 import com.filmdoms.community.account.data.dto.request.UpdatePasswordRequestDto;
 import com.filmdoms.community.account.data.dto.request.UpdateProfileRequestDto;
 import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
 import com.filmdoms.community.account.data.dto.response.LoginResponseDto;
-import com.filmdoms.community.account.data.dto.response.RefreshAccessTokenResponseDto;
+import com.filmdoms.community.account.data.dto.response.AccessTokenResponseDto;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileArticleResponseDto;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileCommentResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
@@ -58,7 +59,7 @@ public class AccountService {
     private final CommentRepository commentRepository;
 
     @Transactional
-    public LoginResponseDto login(String email, String password) {
+    public LoginDto login(String email, String password) {
 
         log.info("가입 여부 확인");
         AccountDto accountDto = accountRepository.findByEmail(email)
@@ -78,14 +79,14 @@ public class AccountService {
         log.info("리프레시 토큰 저장 / 갱신");
         refreshTokenRepository.save(key, refreshToken);
 
-        return LoginResponseDto.builder()
+        return LoginDto.builder()
                 .accessToken(jwtTokenProvider.createAccessToken(String.valueOf(accountDto.getId())))
                 .refreshToken(refreshToken)
                 .build();
     }
 
     @Transactional
-    public RefreshAccessTokenResponseDto refreshAccessToken(String refreshToken) {
+    public AccessTokenResponseDto refreshAccessToken(String refreshToken) {
 
         log.info("토큰 내 저장된 키 추출");
         String key = jwtTokenProvider.getSubject(refreshToken);
@@ -104,7 +105,7 @@ public class AccountService {
 
         log.info("새로운 엑세스 토큰 발급");
         String accessToken = jwtTokenProvider.createAccessToken(key);
-        return RefreshAccessTokenResponseDto.builder()
+        return AccessTokenResponseDto.builder()
                 .accessToken(accessToken)
                 .build();
     }

--- a/src/test/java/com/filmdoms/community/account/service/AccountServiceTest.java
+++ b/src/test/java/com/filmdoms/community/account/service/AccountServiceTest.java
@@ -20,7 +20,7 @@ import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
 import com.filmdoms.community.account.data.dto.request.UpdatePasswordRequestDto;
 import com.filmdoms.community.account.data.dto.request.UpdateProfileRequestDto;
 import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
-import com.filmdoms.community.account.data.dto.response.RefreshAccessTokenResponseDto;
+import com.filmdoms.community.account.data.dto.response.AccessTokenResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.data.entity.Movie;
 import com.filmdoms.community.account.exception.ApplicationException;
@@ -29,6 +29,8 @@ import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.repository.FavoriteMovieRepository;
 import com.filmdoms.community.account.repository.MovieRepository;
 import com.filmdoms.community.account.repository.RefreshTokenRepository;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.comment.repository.CommentRepository;
 import com.filmdoms.community.file.data.entity.File;
 import com.filmdoms.community.file.repository.FileRepository;
 import java.util.List;
@@ -51,27 +53,24 @@ class AccountServiceTest {
 
     @Autowired
     private AccountService accountService;
-
     @MockBean
     private FileRepository fileRepository;
-
     @MockBean
     private AccountRepository accountRepository;
-
     @MockBean
     private RefreshTokenRepository refreshTokenRepository;
-
     @MockBean
     private JwtTokenProvider jwtTokenProvider;
-
     @MockBean
     private PasswordEncoder encoder;
-
     @MockBean
     private MovieRepository movieRepository;
-
     @MockBean
     private FavoriteMovieRepository favoriteMovieRepository;
+    @MockBean
+    private ArticleRepository articleRepository;
+    @MockBean
+    private CommentRepository commentRepository;
 
     @Nested
     @DisplayName("로그인 기능 테스트")
@@ -137,7 +136,7 @@ class AccountServiceTest {
             when(jwtTokenProvider.createAccessToken(key)).thenReturn(accessToken);
 
             // When
-            RefreshAccessTokenResponseDto responseDto = accountService.refreshAccessToken(refreshToken);
+            AccessTokenResponseDto responseDto = accountService.refreshAccessToken(refreshToken);
 
             // Then
             assertThat(responseDto)


### PR DESCRIPTION
이전에는 리프레시 토큰을 액세스 토큰과 함께 Response Body안에 반환했는데,
보안상 위험이 있다는 피드백에 Http Only 쿠키에 담아 반환하도록 수정했습니다.