### PR TITLE
소셜 로그인 기능 로직 수정 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandler.java
@@ -4,16 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.constant.OAuthType;
-import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.response.OAuthResponseDto;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.exception.ApplicationException;
 import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.repository.RefreshTokenRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -21,8 +24,9 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
+import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -31,60 +35,81 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     You also need to ensure the ClientRegistration.redirectUriTemplate matches the custom Authorization Response baseUri -> 프론트/백 나눠서 처리하므로 달라야 함
     */
     private final AccountRepository accountRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
 
     protected void handle(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
-        //Provider로부터 받아온 정보로 회원가입/로그인 진행
         OAuth2AuthenticationToken oAuth2AuthenticationToken = (OAuth2AuthenticationToken) authentication;
 
         if (response.isCommitted()) {
-            super.logger.debug("Response has already been committed.");
+            log.debug("Response has already been committed.");
             return;
         }
 
+        String email = resolveEmailFromAuthentication(oAuth2AuthenticationToken);
+        Account account = accountRepository.findByEmail(email)
+                .orElseGet(() -> createGuestAccountWithEmail(email)); //가입된 이메일이 아닌 경우 GUEST 등급의 Account 생성
+        checkSocialLoginAccount(account); //소셜 로그인 계정 여부 확인
+
+        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(account.getId()));
+        ResponseCookie refreshTokenCookie = resolveRefreshTokenCookieFromEmail(email);
+        OAuthType oAuthType = resolveOAuthTypeFromAccountRole(account.getAccountRole());
+        OAuthResponseDto responseDto = OAuthResponseDto.from(oAuthType, accessToken);
+
+        //Response 객체에 응답을 세팅
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.setHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        response.getWriter()
+                .write(
+                objectMapper.writeValueAsString(
+                        Response.success(responseDto)
+                )
+        );
+    }
+
+    private ResponseCookie resolveRefreshTokenCookieFromEmail(String email) {
+        String refreshTokenKey = UUID.nameUUIDFromBytes(email.getBytes()).toString();
+        String refreshToken = refreshTokenRepository.findByKey(refreshTokenKey)
+                .orElseGet(() -> jwtTokenProvider.createRefreshToken(refreshTokenKey));
+        refreshTokenRepository.save(refreshTokenKey, refreshToken);
+        return jwtTokenProvider.createRefreshTokenCookie(refreshToken);
+    }
+
+    private void checkSocialLoginAccount(Account account) {
+        if (!account.isSocialLogin()) { //소셜 로그인 계정이 아니면 예외 발생 -> 이메일 인증 필수로 구현해야 함 (잘못 기재한 이메일 때문에 이메일 실소유자가 가입을 못하는 경우 방지)
+            throw new ApplicationException(ErrorCode.NOT_SOCIAL_LOGIN_ACCOUNT);
+        }
+    }
+
+    public String resolveEmailFromAuthentication(OAuth2AuthenticationToken oAuth2AuthenticationToken) {
         String registrationId = oAuth2AuthenticationToken.getAuthorizedClientRegistrationId();
         Map<String, Object> attributes = oAuth2AuthenticationToken.getPrincipal().getAttributes();
         String email = AttributeConverter.getEmail(registrationId, attributes); //이메일 정보만 추출
-        Optional<Account> optionalAccount = accountRepository.findByEmail(email);
+        return email;
+    }
 
-        if(optionalAccount.isPresent()) { //이메일과 일치하는 계정이 존재하는 경우
-            Account account = optionalAccount.get();
-            if(!account.isSocialLogin()) { //소셜 로그인 계정이 아니면 예외 발생 -> 이메일 인증 필수로 구현해야 함 (잘못 기재한 이메일 때문에 이메일 실소유자가 가입을 못하는 경우 방지)
-                throw new ApplicationException(ErrorCode.NOT_SOCIAL_LOGIN_ACCOUNT);
-            }
+    private Account createGuestAccountWithEmail(String email) {
+        Account account = Account.builder()
+                .email(email)
+                .role(AccountRole.GUEST)
+                .isSocialLogin(true)
+                .build();
+        return accountRepository.save(account);
+    }
 
-            //이메일과 일치하는 소셜 로그인 계정이 존재하는 경우는 2가지임
-            //추가 정보 입력한 완전한 계정
-            //아직 추가 정보를 입력하지 않은 계정 (GUEST 권한)
-            //아래 5줄은 공통 처리
-            //그 다음은 분기 처리
-            AccountDto accountDto = AccountDto.from(account);
-            String token = jwtTokenProvider.createAccessToken(String.valueOf(accountDto.getId()));
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.setContentType("application/json");
-            response.setCharacterEncoding("utf-8");
-
-            if(accountDto.getAccountRole() != AccountRole.GUEST) {
-                response.getWriter().write(objectMapper.writeValueAsString(Response.success(new OAuthResponseDto(OAuthType.LOGIN, token))));
-            } else {
-                response.getWriter().write(objectMapper.writeValueAsString(Response.success(new OAuthResponseDto(OAuthType.SIGNUP, token))));
-            }
-        } else { //
-            Account newAccount = Account.builder()
-                    .email(email)
-                    .role(AccountRole.GUEST)
-                    .isSocialLogin(true)
-                    .build();
-
-            accountRepository.save(newAccount);
-            AccountDto accountDto = AccountDto.from(newAccount);
-            String token = jwtTokenProvider.createAccessToken(String.valueOf(accountDto.getId()));
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.setContentType("application/json");
-            response.setCharacterEncoding("utf-8");
-            response.getWriter().write(objectMapper.writeValueAsString(Response.success(new OAuthResponseDto(OAuthType.SIGNUP, token))));
+    private OAuthType resolveOAuthTypeFromAccountRole(AccountRole accountRole) {
+        OAuthType oAuthType;
+        switch (accountRole) {
+            case GUEST:
+                oAuthType = OAuthType.SIGNUP;
+                break;
+            default:
+                oAuthType = OAuthType.LOGIN;
         }
+        return oAuthType;
     }
 }

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/OAuthResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/OAuthResponseDto.java
@@ -1,13 +1,20 @@
 package com.filmdoms.community.account.data.dto.response;
 
 import com.filmdoms.community.account.data.constant.OAuthType;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class OAuthResponseDto {
 
     private OAuthType type;
     private String accessToken;
+
+    private OAuthResponseDto(OAuthType type, String accessToken) {
+        this.type = type;
+        this.accessToken = accessToken;
+    }
+
+    public static OAuthResponseDto from(OAuthType type, String accessToken) {
+        return new OAuthResponseDto(type, accessToken);
+    }
 }

--- a/src/test/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandlerTest.java
+++ b/src/test/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandlerTest.java
@@ -1,0 +1,166 @@
+package com.filmdoms.community.account.config.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.constant.OAuthType;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.repository.RefreshTokenRepository;
+import com.filmdoms.community.account.service.TokenAuthenticationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = {
+        JwtTokenProvider.class,
+        ObjectMapper.class
+})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "JWT_KEY=aKeyThatIsVeryLongToBeUsedForJWTKEY"
+})
+@DisplayName("소셜 로그인 로직 테스트")
+class CustomOAuthSuccessHandlerTest {
+
+    @SpyBean
+    CustomOAuthSuccessHandler customOAuthSuccessHandler;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AccountRepository accountRepository;
+
+    @MockBean
+    RefreshTokenRepository refreshTokenRepository;
+
+    @MockBean
+    TokenAuthenticationService tokenAuthenticationService;
+
+    private static final String ACCESS_TOKEN_CAMEL_CASE = "accessToken";
+    private static final String REFRESH_TOKEN_CAMEL_CASE = "refreshToken";
+
+    @Test
+    @DisplayName("신규 이메일의 경우, 계정을 생성하고, 액세스, 리프레시 토큰을 발급하며, SIGNUP 응답이 나감")
+    void newEmail() throws IOException {
+        //given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthenticationToken authentication = null;
+        String testEmail = "testEmail@filmdoms.com";
+        Account mockAccount = createMockAccount(testEmail, AccountRole.GUEST, true);
+
+        doReturn(testEmail).when(customOAuthSuccessHandler).resolveEmailFromAuthentication(authentication);
+        doReturn(Optional.empty()).when(refreshTokenRepository).findByKey(any());
+        doReturn(Optional.empty()).when(accountRepository).findByEmail(testEmail);
+        doReturn(mockAccount).when(accountRepository).save(any());
+
+        //when
+        customOAuthSuccessHandler.handle(request, response, authentication);
+
+        //then
+        String responseContent = response.getContentAsString();
+        verify(accountRepository).save(any());
+        assertThat(responseContent).contains(ACCESS_TOKEN_CAMEL_CASE);
+        assertThat(response.getCookie(REFRESH_TOKEN_CAMEL_CASE)).isNotNull();
+        assertThat(responseContent).contains(OAuthType.SIGNUP.name());
+    }
+
+    @Test
+    @DisplayName("GUEST 등급 소셜 로그인 계정의 경우, 액세스, 리프레시 토큰을 발급하며, SIGNUP 응답이 나감")
+    void guestRoleAccount() throws IOException {
+        //given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthenticationToken authentication = null;
+        String testEmail = "testEmail@filmdoms.com";
+        Account mockAccount = createMockAccount(testEmail, AccountRole.GUEST, true);
+
+        doReturn(testEmail).when(customOAuthSuccessHandler).resolveEmailFromAuthentication(authentication);
+        doReturn(Optional.empty()).when(refreshTokenRepository).findByKey(any());
+        doReturn(Optional.ofNullable(mockAccount)).when(accountRepository).findByEmail(testEmail);
+
+        //when
+        customOAuthSuccessHandler.handle(request, response, authentication);
+
+        //then
+        String responseContent = response.getContentAsString();
+        verify(accountRepository, times(0)).save(any());
+        assertThat(responseContent).contains(ACCESS_TOKEN_CAMEL_CASE);
+        assertThat(response.getCookie(REFRESH_TOKEN_CAMEL_CASE)).isNotNull();
+        assertThat(responseContent).contains(OAuthType.SIGNUP.name());
+    }
+
+    @Test
+    @DisplayName("USER 등급 소셜 로그인 계정의 경우, 액세스, 리프레시 토큰을 발급하며, LOGIN 응답이 나감")
+    void userRoleAccount() throws IOException {
+        //given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthenticationToken authentication = null;
+        String testEmail = "testEmail@filmdoms.com";
+        Account mockAccount = createMockAccount(testEmail, AccountRole.USER, true);
+
+        doReturn(testEmail).when(customOAuthSuccessHandler).resolveEmailFromAuthentication(authentication);
+        doReturn(Optional.empty()).when(refreshTokenRepository).findByKey(any());
+        doReturn(Optional.ofNullable(mockAccount)).when(accountRepository).findByEmail(testEmail);
+
+        //when
+        customOAuthSuccessHandler.handle(request, response, authentication);
+
+        //then
+        String responseContent = response.getContentAsString();
+        verify(accountRepository, times(0)).save(any());
+        assertThat(responseContent).contains(ACCESS_TOKEN_CAMEL_CASE);
+        assertThat(response.getCookie(REFRESH_TOKEN_CAMEL_CASE)).isNotNull();
+        assertThat(responseContent).contains(OAuthType.LOGIN.name());
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 계정이 아닌 경우 에러 발생")
+    void NotSocialLoginAccount() {
+        //given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthenticationToken authentication = null;
+        String testEmail = "testEmail@filmdoms.com";
+        Account mockAccount = createMockAccount(testEmail, AccountRole.USER, false);
+
+        doReturn(testEmail).when(customOAuthSuccessHandler).resolveEmailFromAuthentication(authentication);
+        doReturn(Optional.empty()).when(refreshTokenRepository).findByKey(any());
+        doReturn(Optional.ofNullable(mockAccount)).when(accountRepository).findByEmail(testEmail);
+
+        //when & then
+        ApplicationException exception = assertThrows(ApplicationException.class, () -> customOAuthSuccessHandler.handle(request, response, authentication));
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_SOCIAL_LOGIN_ACCOUNT);
+    }
+
+    private Account createMockAccount(String email, AccountRole role, boolean isSocialLogin) {
+        return Account.builder()
+                .email(email)
+                .role(role)
+                .isSocialLogin(isSocialLogin)
+                .build();
+    }
+}


### PR DESCRIPTION
소셜 로그인 시 리프레시 토큰 쿠키를 설정하도록 변경하고, 내부 로직을 가독성을 높이는 방향으로 리팩토링 했습니다.
테스트 코드도 작성 완료했습니다. (최대한 간단하게 작성해 보려고 했지만, 해당 핸들러가 의존성이 많아 테스트 코드가 길어졌습니다.)