### PR TITLE
리프레시 토큰 기능 수정 및 프로필 요청 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import com.filmdoms.community.account.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -46,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/account/oauth").hasRole("GUEST")
                         .requestMatchers(HttpMethod.POST, "/api/v1/account/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/account/profile").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/email/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/banner").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/v1/banner/**").hasRole("ADMIN")
@@ -79,7 +79,7 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(Arrays.asList("https://film-doms.vercel.app","http://localhost:*"));
+        configuration.setAllowedOriginPatterns(Arrays.asList("https://film-doms.vercel.app", "http://localhost:*"));
         configuration.setAllowedMethods(Arrays.asList("*"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "토큰이 첨부되지 않았습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
-    TOKEN_NOT_IN_DB(HttpStatus.NOT_FOUND, "저장된 리프레시 토큰을 찾지 못했습니다. 만료되었거나, 액세스 토큰을 잘못 보내지 않았는지 확인해주세요."),
+    TOKEN_NOT_IN_DB(HttpStatus.BAD_REQUEST, "저장된 리프레시 토큰을 찾지 못했습니다. 만료되었거나, 액세스 토큰을 잘못 보내지 않았는지 확인해주세요."),
     URI_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI가 존재하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 주소의 게시판이 존재하지 않습니다."),
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 주소의 태그가 존재하지 않습니다."),

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -87,7 +87,13 @@ public class AccountService {
     public AccessTokenResponseDto refreshAccessToken(String refreshToken) {
 
         log.info("토큰 내 저장된 키 추출");
-        String key = jwtTokenProvider.getSubject(refreshToken);
+        String key;
+        try {
+            key = jwtTokenProvider.getSubject(refreshToken);
+        } catch (Exception e) {
+            throw new ApplicationException(ErrorCode.INVALID_TOKEN);
+        }
+        log.info("{}", key);
 
         log.info("키로 저장된 토큰 호출");
         String savedToken = refreshTokenRepository.findByKey(key)
@@ -103,7 +109,7 @@ public class AccountService {
 
         Optional<Account> optionalAccount = accountRepository.findByEmail(key);
         if (optionalAccount.isEmpty()) {
-            throw new ApplicationException(ErrorCode.AUTHENTICATION_ERROR);
+            throw new ApplicationException(ErrorCode.INVALID_TOKEN);
         }
         Account account = optionalAccount.get();
         log.info("새로운 엑세스 토큰 발급");

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -29,14 +29,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -70,7 +69,7 @@ public class AccountService {
         }
 
         log.info("저장된 토큰 존재 여부 확인, 없다면 생성");
-        String key = accountDto.getEmail();
+        String key = accountDto.getId().toString();
         String refreshToken = refreshTokenRepository.findByKey(key)
                 .orElseGet(() -> jwtTokenProvider.createRefreshToken(key));
 
@@ -107,13 +106,8 @@ public class AccountService {
         log.info("리프레시 토큰 갱신");
         refreshTokenRepository.save(key, refreshToken);
 
-        Optional<Account> optionalAccount = accountRepository.findByEmail(key);
-        if (optionalAccount.isEmpty()) {
-            throw new ApplicationException(ErrorCode.INVALID_TOKEN);
-        }
-        Account account = optionalAccount.get();
         log.info("새로운 엑세스 토큰 발급");
-        String accessToken = jwtTokenProvider.createAccessToken(account.getId().toString());
+        String accessToken = jwtTokenProvider.createAccessToken(key);
 
         return AccessTokenResponseDto.builder()
                 .accessToken(accessToken)


### PR DESCRIPTION
프로필 요청의 경우 요청을 토큰으로 받기 때문에 해당부분 Config 변경했습니다.

리프레시 토큰의 경우에는, 리프레시 토큰에서 새로 엑세스 토큰을 만들 때 키와(UUID.nameUUIDFromBytes(email.getBytes()))
처음 로그인시 엑세스 토큰을 만들 때의 키가(long accountid) 달라서, 리프레시 토큰을 이용해 엑세스 토큰을 새로 발급 받고 동작 시도시 문제가 발생했었습니다.
코드 확인 후 레디스에 저장시에 문제가 되는 것 같아 해당부분 로직 수정하였습니다.

프론트엔드팀과 이야기 해본 결과, 리프레시 토큰이 잘못된 토큰이거나, 리프레시 토큰이 없는 경우 400에러를 반환해야 하고
해당 부분에 대한 내용이 표준으로 되어 있어서 해당 경우에 대해서 400에러를 반환하도록 수정하였습니다.
