### PR TITLE
소셜 로그인 시 리프레시 토큰에 저장되는 정보 변경

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandler.java
@@ -55,7 +55,7 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             checkSocialLoginAccount(account); //소셜 로그인 계정 여부 확인
 
             String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(account.getId()));
-            ResponseCookie refreshTokenCookie = resolveRefreshTokenCookieFromEmail(email);
+            ResponseCookie refreshTokenCookie = resolveRefreshTokenCookieFromAccount(account);
             OAuthType oAuthType = resolveOAuthTypeFromAccountRole(account.getAccountRole());
             OAuthResponseDto responseDto = OAuthResponseDto.from(oAuthType, accessToken);
 
@@ -87,8 +87,8 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                 );
     }
 
-    private ResponseCookie resolveRefreshTokenCookieFromEmail(String email) {
-        String refreshTokenKey = UUID.nameUUIDFromBytes(email.getBytes()).toString();
+    private ResponseCookie resolveRefreshTokenCookieFromAccount(Account account) {
+        String refreshTokenKey = String.valueOf(account.getId());
         String refreshToken = refreshTokenRepository.findByKey(refreshTokenKey)
                 .orElseGet(() -> jwtTokenProvider.createRefreshToken(refreshTokenKey));
         refreshTokenRepository.save(refreshTokenKey, refreshToken);

--- a/src/test/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandlerTest.java
+++ b/src/test/java/com/filmdoms/community/account/config/oauth/CustomOAuthSuccessHandlerTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest(classes = {
@@ -138,8 +137,8 @@ class CustomOAuthSuccessHandlerTest {
     }
 
     @Test
-    @DisplayName("소셜 로그인 계정이 아닌 경우 에러 발생")
-    void NotSocialLoginAccount() {
+    @DisplayName("소셜 로그인 계정이 아닌 경우 에러 응답 발생")
+    void NotSocialLoginAccount() throws IOException {
         //given
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -152,8 +151,9 @@ class CustomOAuthSuccessHandlerTest {
         doReturn(Optional.ofNullable(mockAccount)).when(accountRepository).findByEmail(testEmail);
 
         //when & then
-        ApplicationException exception = assertThrows(ApplicationException.class, () -> customOAuthSuccessHandler.handle(request, response, authentication));
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_SOCIAL_LOGIN_ACCOUNT);
+        customOAuthSuccessHandler.handle(request, response, authentication);
+        String responseContent = response.getContentAsString();
+        assertThat(responseContent).contains(ErrorCode.NOT_SOCIAL_LOGIN_ACCOUNT.name());
     }
 
     private Account createMockAccount(String email, AccountRole role, boolean isSocialLogin) {


### PR DESCRIPTION
로그인 시 리프레시 토큰에 넣어주는 정보가 email 해시값에서 id로 변경됨에 따라 소셜 로그인 로직에도 해당 사항을 반영했습니다.

추가적으로 기존 소셜 로그인 기능의 예외 처리 로직이 수정됨에 따라([해당 커밋](https://github.com/YOUNGHO0/Filmdoms_Project/pull/159/commits/192871e9523e2609d48713ff87802ae5f2311a71)) 테스트가 실패하는 문제를 해결했습니다.