### PR TITLE
리다이렉트 URI에 독립적으로 작동하고, 인증 실패시 JSON 응답을 주도록 소셜 로그인 기능 변경

### DIFF
--- a/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/account/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.filmdoms.community.account.config;
 
 import com.filmdoms.community.account.config.jwt.JwtAuthenticationFilter;
 import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.account.config.oauth.CustomOAuth2AuthorizationRequestResolver;
+import com.filmdoms.community.account.config.oauth.CustomOAuthFailureHandler;
 import com.filmdoms.community.account.config.oauth.CustomOAuthSuccessHandler;
 import com.filmdoms.community.account.exception.CustomAccessDeniedHandler;
 import com.filmdoms.community.account.exception.CustomAuthenticationEntryPoint;
@@ -27,6 +29,8 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuthSuccessHandler customOAuthSuccessHandler;
+    private final CustomOAuthFailureHandler customOAuthFailureHandler;
+    private final CustomOAuth2AuthorizationRequestResolver customOAuth2AuthorizationRequestResolver;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -69,8 +73,12 @@ public class SecurityConfig {
                         OAuth2LoginAuthenticationFilter.class)
 
                 //oauth 관련 설정
-                .oauth2Login()
-                .successHandler(customOAuthSuccessHandler);
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .authorizationRequestResolver(customOAuth2AuthorizationRequestResolver))
+                        .successHandler(customOAuthSuccessHandler)
+                        .failureHandler(customOAuthFailureHandler)
+                );
 
         return http.build();
     }

--- a/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,270 @@
+package com.filmdoms.community.account.config.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.keygen.Base64StringKeyGenerator;
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+@Slf4j
+@Component
+public final class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private static String oauth2GoogleRedirectPath;
+
+    private static final String REGISTRATION_ID_URI_VARIABLE_NAME = "registrationId";
+
+    private static final char PATH_DELIMITER = '/';
+
+    private static final StringKeyGenerator DEFAULT_STATE_GENERATOR = new Base64StringKeyGenerator(
+            Base64.getUrlEncoder());
+
+    private static final StringKeyGenerator DEFAULT_SECURE_KEY_GENERATOR = new Base64StringKeyGenerator(
+            Base64.getUrlEncoder().withoutPadding(), 96);
+
+    private static final Consumer<OAuth2AuthorizationRequest.Builder> DEFAULT_PKCE_APPLIER = OAuth2AuthorizationRequestCustomizers
+            .withPkce();
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    private final AntPathRequestMatcher authorizationRequestMatcher;
+
+    private Consumer<OAuth2AuthorizationRequest.Builder> authorizationRequestCustomizer = (customizer) -> {
+    };
+
+    /**
+     * Constructs a {@code DefaultOAuth2AuthorizationRequestResolver} using the provided
+     * parameters.
+     *
+     * @param clientRegistrationRepository the repository of client registrations
+     *                                     authorization requests
+     */
+    public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        Assert.notNull(clientRegistrationRepository, "clientRegistrationRepository cannot be null");
+        this.clientRegistrationRepository = clientRegistrationRepository;
+        this.authorizationRequestMatcher = new AntPathRequestMatcher(
+                OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/{" + REGISTRATION_ID_URI_VARIABLE_NAME + "}");
+    }
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-path}")
+    private void setOauth2GoogleRedirectPath(String redirectPath) {
+        oauth2GoogleRedirectPath = redirectPath;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        String registrationId = resolveRegistrationId(request);
+        if (registrationId == null) {
+            return null;
+        }
+        String redirectUriAction = getAction(request, "login");
+        return resolve(request, registrationId, redirectUriAction);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String registrationId) {
+        if (registrationId == null) {
+            return null;
+        }
+        String redirectUriAction = getAction(request, "authorize");
+        return resolve(request, registrationId, redirectUriAction);
+    }
+
+    /**
+     * Sets the {@code Consumer} to be provided the
+     * {@link OAuth2AuthorizationRequest.Builder} allowing for further customizations.
+     *
+     * @param authorizationRequestCustomizer the {@code Consumer} to be provided the
+     *                                       {@link OAuth2AuthorizationRequest.Builder}
+     * @see OAuth2AuthorizationRequestCustomizers
+     * @since 5.3
+     */
+    public void setAuthorizationRequestCustomizer(
+            Consumer<OAuth2AuthorizationRequest.Builder> authorizationRequestCustomizer) {
+        Assert.notNull(authorizationRequestCustomizer, "authorizationRequestCustomizer cannot be null");
+        this.authorizationRequestCustomizer = authorizationRequestCustomizer;
+    }
+
+    private String getAction(HttpServletRequest request, String defaultAction) {
+        String action = request.getParameter("action");
+        if (action == null) {
+            return defaultAction;
+        }
+        return action;
+    }
+
+    private OAuth2AuthorizationRequest resolve(HttpServletRequest request, String registrationId,
+                                               String redirectUriAction) {
+        if (registrationId == null) {
+            return null;
+        }
+        ClientRegistration clientRegistration = this.clientRegistrationRepository.findByRegistrationId(registrationId);
+        if (clientRegistration == null) {
+            throw new RuntimeException("Invalid Client Registration with Id: " + registrationId);
+        }
+        OAuth2AuthorizationRequest.Builder builder = getBuilder(clientRegistration);
+
+        String redirectUriStr = expandRedirectUri(request, clientRegistration, redirectUriAction);
+
+        // @formatter:off
+        builder.clientId(clientRegistration.getClientId())
+                .authorizationUri(clientRegistration.getProviderDetails().getAuthorizationUri())
+                .redirectUri(redirectUriStr)
+                .scopes(clientRegistration.getScopes())
+                .state(DEFAULT_STATE_GENERATOR.generateKey());
+        // @formatter:on
+
+        this.authorizationRequestCustomizer.accept(builder);
+
+        return builder.build();
+    }
+
+    private OAuth2AuthorizationRequest.Builder getBuilder(ClientRegistration clientRegistration) {
+        if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(clientRegistration.getAuthorizationGrantType())) {
+            // @formatter:off
+            OAuth2AuthorizationRequest.Builder builder = OAuth2AuthorizationRequest.authorizationCode()
+                    .attributes((attrs) ->
+                            attrs.put(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId()));
+            // @formatter:on
+            if (!CollectionUtils.isEmpty(clientRegistration.getScopes())
+                    && clientRegistration.getScopes().contains(OidcScopes.OPENID)) {
+                // Section 3.1.2.1 Authentication Request -
+                // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest scope
+                // REQUIRED. OpenID Connect requests MUST contain the "openid" scope
+                // value.
+                applyNonce(builder);
+            }
+            if (ClientAuthenticationMethod.NONE.equals(clientRegistration.getClientAuthenticationMethod())) {
+                DEFAULT_PKCE_APPLIER.accept(builder);
+            }
+            return builder;
+        }
+        throw new IllegalArgumentException(
+                "Invalid Authorization Grant Type (" + clientRegistration.getAuthorizationGrantType().getValue()
+                        + ") for Client Registration with Id: " + clientRegistration.getRegistrationId());
+    }
+
+    private String resolveRegistrationId(HttpServletRequest request) {
+        if (this.authorizationRequestMatcher.matches(request)) {
+            return this.authorizationRequestMatcher.matcher(request).getVariables()
+                    .get(REGISTRATION_ID_URI_VARIABLE_NAME);
+        }
+        return null;
+    }
+
+    /**
+     * Expands the {@link ClientRegistration#getRedirectUri()} with following provided
+     * variables:<br/>
+     * - baseUrl (e.g. https://localhost/app) <br/>
+     * - baseScheme (e.g. https) <br/>
+     * - baseHost (e.g. localhost) <br/>
+     * - basePort (e.g. :8080) <br/>
+     * - basePath (e.g. /app) <br/>
+     * - registrationId (e.g. google) <br/>
+     * - action (e.g. login) <br/>
+     * <p/>
+     * Null variables are provided as empty strings.
+     * <p/>
+     * Default redirectUri is:
+     * {@code org.springframework.security.config.oauth2.client.CommonOAuth2Provider#DEFAULT_REDIRECT_URL}
+     * @return expanded URI
+     */
+    private static String expandRedirectUri(HttpServletRequest request, ClientRegistration clientRegistration,
+                                            String action) {
+        //새 로직
+        String referer = request.getHeader("Referer");
+        if (referer != null && StringUtils.hasText(oauth2GoogleRedirectPath)) {
+            if (referer.endsWith("/")) referer = referer.substring(0, referer.length() - 1);
+            if (oauth2GoogleRedirectPath.startsWith("/")) {
+                return referer + oauth2GoogleRedirectPath;
+            } else {
+                return referer + "/" + oauth2GoogleRedirectPath;
+            }
+        }
+
+        //원래 로직
+        Map<String, String> uriVariables = new HashMap<>();
+        uriVariables.put("registrationId", clientRegistration.getRegistrationId());
+        // @formatter:off
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+                .replacePath(request.getContextPath())
+                .replaceQuery(null)
+                .fragment(null)
+                .build();
+        // @formatter:on
+        String scheme = uriComponents.getScheme();
+        uriVariables.put("baseScheme", (scheme != null) ? scheme : "");
+        String host = uriComponents.getHost();
+        uriVariables.put("baseHost", (host != null) ? host : "");
+        // following logic is based on HierarchicalUriComponents#toUriString()
+        int port = uriComponents.getPort();
+        uriVariables.put("basePort", (port == -1) ? "" : ":" + port);
+        String path = uriComponents.getPath();
+        if (StringUtils.hasLength(path)) {
+            if (path.charAt(0) != PATH_DELIMITER) {
+                path = PATH_DELIMITER + path;
+            }
+        }
+        uriVariables.put("basePath", (path != null) ? path : "");
+        uriVariables.put("baseUrl", uriComponents.toUriString());
+        uriVariables.put("action", (action != null) ? action : "");
+        return UriComponentsBuilder.fromUriString(clientRegistration.getRedirectUri()).buildAndExpand(uriVariables)
+                .toUriString();
+    }
+
+    /**
+     * Creates nonce and its hash for use in OpenID Connect 1.0 Authentication Requests.
+     * @param builder where the {@link OidcParameterNames#NONCE} and hash is stored for
+     * the authentication request
+     *
+     * @since 5.2
+     * @see <a target="_blank" href=
+     * "https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">3.1.2.1.
+     * Authentication Request</a>
+     */
+    private static void applyNonce(OAuth2AuthorizationRequest.Builder builder) {
+        try {
+            String nonce = DEFAULT_SECURE_KEY_GENERATOR.generateKey();
+            String nonceHash = createHash(nonce);
+            builder.attributes((attrs) -> attrs.put(OidcParameterNames.NONCE, nonce));
+            builder.additionalParameters((params) -> params.put(OidcParameterNames.NONCE, nonceHash));
+        }
+        catch (NoSuchAlgorithmException ex) {
+        }
+    }
+
+    private static String createHash(String value) throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] digest = md.digest(value.getBytes(StandardCharsets.US_ASCII));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+    }
+
+}

--- a/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuthFailureHandler.java
+++ b/src/main/java/com/filmdoms/community/account/config/oauth/CustomOAuthFailureHandler.java
@@ -1,0 +1,43 @@
+package com.filmdoms.community.account.config.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filmdoms.community.account.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.account.exception.ApplicationException;
+import com.filmdoms.community.account.exception.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuthFailureHandler implements AuthenticationFailureHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        createApplicationExceptionResponse(response, new ApplicationException(ErrorCode.SOCIAL_LOGIN_FAILED));
+    }
+
+    private void createApplicationExceptionResponse(HttpServletResponse response, ApplicationException e) throws IOException {
+        response.setStatus(e.getErrorCode().getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter()
+                .write(
+                        objectMapper.writeValueAsString(
+                                Response.error(e.getErrorCode().name())
+                        )
+                );
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/account/exception/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
     ALREADY_REGISTERED_ANNOUNCE(HttpStatus.BAD_REQUEST,"이미 등록된 공지사항입니다"),
     ALREADY_UNREGISTERED_ANNOUNCE(HttpStatus.BAD_REQUEST,"이미 등록해제된 공지사항입니다"),
     INVALID_ANNOUNCE_ID(HttpStatus.BAD_REQUEST,"존재하지 않는 공지사항입니다"),
-    INVALID_TAG(HttpStatus.BAD_REQUEST, "해당 카테고리에 존재하지 않는 태그입니다.");
+    INVALID_TAG(HttpStatus.BAD_REQUEST, "해당 카테고리에 존재하지 않는 태그입니다."),
+    SOCIAL_LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,11 @@ server:
   error:
     whitelabel:
       enabled: false
+  servlet:
+    session:
+      cookie:
+        same-site: none
+        secure: true
 
 domain: ${DOMAIN}
 admin-password: ${ADMIN}
@@ -69,7 +74,7 @@ spring:
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://svc.sel4.cloudtype.app:30330/filmdoms
+    url: jdbc:mariadb://${DB_HOST}:${DB_PORT}/filmdoms
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 

--- a/src/main/resources/config/oauth/application.yml
+++ b/src/main/resources/config/oauth/application.yml
@@ -8,3 +8,4 @@ spring:
             client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
             scope: email
             redirect-uri: ${OAUTH_GOOGLE_REDIRECT_URI}
+            redirect-path: /auth/google

--- a/src/main/resources/config/oauth/application.yml
+++ b/src/main/resources/config/oauth/application.yml
@@ -7,4 +7,4 @@ spring:
             client-id: ${OAUTH_GOOGLE_CLIENT_ID}
             client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
             scope: email
-            redirect-uri: "{baseUrl}/front/oauth2/google"
+            redirect-uri: ${OAUTH_GOOGLE_REDIRECT_URI}

--- a/src/main/resources/config/redis/application.yml
+++ b/src/main/resources/config/redis/application.yml
@@ -20,6 +20,6 @@ spring:
 
   data:
     redis:
-      host: svc.sel3.cloudtype.app
-      port: 30000
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
       password: ${REDIS_SECRET}


### PR DESCRIPTION
소셜 로그인 관련 커스텀 빈을 추가했습니다.

* 기존에는 yml 파일에 등록된 redirect-uri로 고정적으로 리다이렉트 되었으나, 클라이언트에서 받은 레퍼러 정보에 yml에 설정한 path 정보를 합쳐서 동적으로 redirect-uri를 설정하도록 변경했습니다. 해당 redirect-uri는 구글 클라우드 플랫폼 프로젝트에 등록되어 있어야 정상 처리됩니다.
  * 예를 들어 클라이언트에서 `/oauth2/authorization/google`에 로그인 페이지 요청시 `Referer: http://localhost:3000/` 이고 yml에 `redirect-uri`가 `/auth/google`로 설정되어 있으면 리다이렉트 URI가 `http://localhost:3000/auth/google`로 설정됩니다. 그리고 해당 URI가 클라우드 플랫폼에 등록되어 있는 경우에만 정상적으로 로그인 페이지로 넘어갑니다.
  * Referer 헤더 정보나 path 정보가 없는 경우에는 기존 동작을 그대로 수행하도록 했습니다.

* 기존에 OAuth 인증 과정에서 예외가 발생하는 경우 기본 핸들러인 `SimpleUrlAuthenticationFailureHandler`가 작동해서 404 에러가 발생하는 이슈가 있었는데, 커스텀 핸들러를 등록해서 500 상태 코드를 가지는 JSON 응답이 나가도록 변경했습니다.

* 세션 ID를 가지는 쿠키가 `SameSite=Lax` 옵션 때문에 서버로 넘어가지 않는 이슈를 수정했습니다. `SameSite=None; Secure`로 쿠키 속성을 변경했습니다.