### PR TITLE
프로필 응답에 가입일 추가 외 마이페이지 메서드 분리

### DIFF
--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -5,6 +5,9 @@ import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.LoginDto;
 import com.filmdoms.community.account.data.dto.request.*;
+import com.filmdoms.community.account.data.dto.request.profile.UpdateFavoriteMoviesDto;
+import com.filmdoms.community.account.data.dto.request.profile.UpdateNicknameRequestDto;
+import com.filmdoms.community.account.data.dto.request.profile.UpdateProfileImageRequestDto;
 import com.filmdoms.community.account.data.dto.response.AccessTokenResponseDto;
 import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
 import com.filmdoms.community.account.data.dto.response.CheckDuplicateResponseDto;
@@ -12,11 +15,8 @@ import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileArticleResponseDto;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileCommentResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
-import com.filmdoms.community.account.exception.ApplicationException;
-import com.filmdoms.community.account.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.service.AccountService;
-import com.filmdoms.community.account.service.utils.RedisUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -125,11 +125,38 @@ public class AccountController {
         return Response.success(accountService.readAccount(accountDto));
     }
 
-    @PutMapping("/profile")
-    public Response<Void> updateProfile(
-            @RequestBody UpdateProfileRequestDto requestDto,
+//    @PutMapping("/profile")
+//    public Response<Void> updateProfile(
+//            @RequestBody UpdateProfileRequestDto requestDto,
+//            @AuthenticationPrincipal AccountDto accountDto) {
+//        accountService.updateAccountProfile(requestDto, accountDto);
+//        return Response.success();
+//    }
+
+    @PutMapping("/profile/nickname")
+    public Response<Void> updateNickname(
+            @RequestBody UpdateNicknameRequestDto requestDto,
             @AuthenticationPrincipal AccountDto accountDto) {
-        accountService.updateAccountProfile(requestDto, accountDto);
+
+        accountService.updateNickname(requestDto, accountDto);
+        return Response.success();
+    }
+
+    @PutMapping("/profile/favoritemovie")
+    public Response<AccountResponseDto> updateFavoriteMovie(
+            @RequestBody UpdateFavoriteMoviesDto requestDto,
+            @AuthenticationPrincipal AccountDto accountDto) {
+
+        return Response.success(accountService.updateFavoriteMovie(requestDto, accountDto));
+
+    }
+
+    @PutMapping("/profile/profileimage")
+    public Response<Void> updateProfileImage(
+            @RequestBody UpdateProfileImageRequestDto requestDto,
+            @AuthenticationPrincipal AccountDto accountDto) {
+
+        accountService.updateProfileImage(requestDto, accountDto);
         return Response.success();
     }
 

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/profile/UpdateFavoriteMoviesDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/profile/UpdateFavoriteMoviesDto.java
@@ -1,0 +1,15 @@
+package com.filmdoms.community.account.data.dto.request.profile;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.List;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.LIST_TOO_BIG;
+
+@Getter
+public class UpdateFavoriteMoviesDto {
+
+    @Size(max = 5, message = "좋아하는 영화 " + LIST_TOO_BIG)
+    private List<String> favoriteMovies;
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/profile/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/profile/UpdateNicknameRequestDto.java
@@ -1,0 +1,16 @@
+package com.filmdoms.community.account.data.dto.request.profile;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.UNMATCHED_NICKNAME;
+
+@Getter
+public class UpdateNicknameRequestDto {
+    @Min(value = 2, message = UNMATCHED_NICKNAME)
+    @Max(value = 20, message = UNMATCHED_NICKNAME)
+    private String newNickname;
+
+
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/request/profile/UpdateProfileImageRequestDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/request/profile/UpdateProfileImageRequestDto.java
@@ -1,0 +1,14 @@
+package com.filmdoms.community.account.data.dto.request.profile;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import static com.filmdoms.community.account.exception.ValidationMessage.IMAGE_REQUIRED;
+
+@Getter
+public class UpdateProfileImageRequestDto {
+
+    @NotNull(message = IMAGE_REQUIRED)
+    private Long imageId;
+
+}

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/AccountResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/AccountResponseDto.java
@@ -6,6 +6,9 @@ import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.data.entity.Movie;
 import com.filmdoms.community.account.data.entity.FavoriteMovie;
 import com.filmdoms.community.file.data.dto.response.FileResponseDto;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -17,13 +20,14 @@ import lombok.Getter;
 public class AccountResponseDto {
 
     private Long id;
+
+    private Long registeredAt;
     private String nickname;
     private String email;
     private AccountRole accountRole;
     private AccountStatus accountStatus;
     private boolean isSocialLogin;
     private FileResponseDto profileImage;
-
     private List<String> favoriteMovies;
 
     private AccountResponseDto(Account account, List<FavoriteMovie> favoriteMovies) {
@@ -34,6 +38,7 @@ public class AccountResponseDto {
         this.accountStatus = account.getAccountStatus();
         this.isSocialLogin = account.isSocialLogin();
         this.profileImage = FileResponseDto.from(account.getProfileImage());
+        this.registeredAt = ZonedDateTime.of(account.getDateCreated(), ZoneId.systemDefault()).toInstant().toEpochMilli();
         this.favoriteMovies = favoriteMovies.stream()
                 .map(FavoriteMovie::getMovie)
                 .map(Movie::getName)

--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -4,14 +4,13 @@ import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.constant.AccountStatus;
 import com.filmdoms.community.file.data.entity.File;
 import jakarta.persistence.*;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Entity
 @Table(name = "account", indexes = {
@@ -70,8 +69,11 @@ public class Account extends BaseTimeEntity {
         this.password = password;
     }
 
-    public void updateProfile(String nickname, File profileImage) {
+    public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateProfileImage(File profileImage) {
         this.profileImage = profileImage;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
   jpa:
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
1.프로필 응답에 가입일이 없어서 가입일 추가하였습니다.

2. 마이 페이지 메서드에서 닉네임, 프로필 이미지, 좋아하는 영화를 동시에  업데이트 하는것을 확인하였고
기획 상에서 원하는 요소를 변경 버튼을  눌러 변경하기에, 메서드를 분리하였습니다.
