### PR TITLE
Account 엔티티 build시 프로필 이미지 의존성 삭제

### DIFF
--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -125,14 +125,6 @@ public class AccountController {
         return Response.success(accountService.readAccount(accountDto));
     }
 
-//    @PutMapping("/profile")
-//    public Response<Void> updateProfile(
-//            @RequestBody UpdateProfileRequestDto requestDto,
-//            @AuthenticationPrincipal AccountDto accountDto) {
-//        accountService.updateAccountProfile(requestDto, accountDto);
-//        return Response.success();
-//    }
-
     @PutMapping("/profile/nickname")
     public Response<Void> updateNickname(
             @RequestBody UpdateNicknameRequestDto requestDto,

--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -53,16 +53,19 @@ public class Account extends BaseTimeEntity {
 
     @JoinColumn(name = "file_id")
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private File profileImage;
+    private File profileImage = File.builder()
+            .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+            .originalFileName("original_file_name")
+            .build();
 
     @Builder
-    private Account(String nickname, String password, AccountRole role, String email, boolean isSocialLogin, File profileImage) {
+    private Account(String nickname, String password, AccountRole role, String email, boolean isSocialLogin) {
         this.nickname = nickname;
         this.password = password;
         this.email = email;
         this.accountRole = Optional.ofNullable(role).orElse(AccountRole.USER);
         this.isSocialLogin = isSocialLogin;
-        this.profileImage = profileImage;
+
     }
 
     public void updatePassword(String password) {

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -171,7 +171,6 @@ public class AccountService {
                 .nickname(requestDto.getNickname())
                 .email(requestDto.getEmail())
                 .role(AccountRole.USER)
-                .profileImage(getDefaultImage())
                 .build();
 
         log.info("Account 엔티티 저장");
@@ -193,16 +192,6 @@ public class AccountService {
         redisUtil.deleteKey(requestDto.getEmailAuthUuid());
     }
 
-    // TODO: 프로필 기본 이미지 어떻게 처리할 지 상의 필요
-    private File getDefaultImage() {
-        return fileRepository.findById(1L).orElseGet(() -> fileRepository.save(
-                        File.builder()
-                                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
-                                .originalFileName("original_file_name")
-                                .build()
-                )
-        );
-    }
 
     public AccountResponseDto readAccount(AccountDto accountDto) {
 

--- a/src/main/java/com/filmdoms/community/article/service/InitService.java
+++ b/src/main/java/com/filmdoms/community/article/service/InitService.java
@@ -60,7 +60,6 @@ public class InitService {
                 .email("admin@filmdoms.com")
                 .nickname("ironman")
                 .role(AccountRole.ADMIN)
-                .profileImage(defaultImage) //프로필 이미지를 디폴트 이미지로 세팅
                 .build();
         accountRepository.save(admin);
 

--- a/src/main/java/com/filmdoms/community/article/service/InitServiceGenerator.java
+++ b/src/main/java/com/filmdoms/community/article/service/InitServiceGenerator.java
@@ -49,7 +49,6 @@ public class InitServiceGenerator {
         Account user = Account.builder() //게시글, 댓글과 매핑될 Account 생성
                 .nickname(nickname)
                 .role(role)
-                .profileImage(progfileImage) //프로필 이미지를 디폴트 이미지로 세팅
                 .build();
         accountRepository.save(user);
         return user;

--- a/src/test/java/com/filmdoms/community/account/service/AccountServiceTest.java
+++ b/src/test/java/com/filmdoms/community/account/service/AccountServiceTest.java
@@ -468,7 +468,6 @@ class AccountServiceTest {
                 .email(email)
                 .role(AccountRole.USER)
                 .isSocialLogin(false)
-                .profileImage(mockOriginalImage)
                 .build();
         ReflectionTestUtils.setField(mockAccount, Account.class, "id", 1L, Long.class);
 

--- a/src/test/java/com/filmdoms/community/testentityprovider/TestAccountProvider.java
+++ b/src/test/java/com/filmdoms/community/testentityprovider/TestAccountProvider.java
@@ -26,7 +26,6 @@ public class TestAccountProvider {
                 .email("test_email_" + count + "@filmdoms.com")
                 .password("test_password")
                 .role(AccountRole.USER)
-                .profileImage(profileImage)
                 .build();
         return account;
     }


### PR DESCRIPTION
기존에는 Account 엔티티를 Build시에 프로필 이미지를 넣어주어야만 했습니다.
이 부분 때문에, 프로필 이미지를 여러번 만들게 되었고, 프로필 이미지가 없는 경우는 널포인터 예외를 만들기도 하였습니다.
따라서, Account 엔티티에서 프로필 이미지 의존성을 삭제하였습니다.

그 외에 주석 처리된 코드, 테스트 코드에서 프로필 이미지를 같이 빌드하는 부분 수정하였습니다.
