### PR TITLE
한번 생성된 Account 이미지를 회원가입시 계속 사용하게 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/DefaultProfileImage.java
+++ b/src/main/java/com/filmdoms/community/account/data/DefaultProfileImage.java
@@ -1,0 +1,31 @@
+package com.filmdoms.community.account.data;
+
+import com.filmdoms.community.file.data.entity.File;
+import com.filmdoms.community.file.repository.FileRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@RequiredArgsConstructor
+public class DefaultProfileImage {
+
+    private final FileRepository fileRepository;
+    private File defaultProfileImage;
+
+    @PostConstruct
+    public void init() {
+
+        File file = File.builder()
+                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                .originalFileName("original_file_name")
+                .build();
+        defaultProfileImage = fileRepository.save(file);
+
+    }
+
+}
+
+

--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -52,7 +52,7 @@ public class Account extends BaseTimeEntity {
     private boolean isSocialLogin;
 
     @JoinColumn(name = "file_id")
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     private File profileImage;
 
     @Builder

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -1,6 +1,6 @@
 package com.filmdoms.community.account.service;
 
-import com.filmdoms.community.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.account.data.DefaultProfileImage;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.LoginDto;
@@ -15,8 +15,6 @@ import com.filmdoms.community.account.data.dto.response.profile.ProfileCommentRe
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.data.entity.FavoriteMovie;
 import com.filmdoms.community.account.data.entity.Movie;
-import com.filmdoms.community.exception.ApplicationException;
-import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.repository.FavoriteMovieRepository;
 import com.filmdoms.community.account.repository.MovieRepository;
@@ -26,6 +24,9 @@ import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.article.repository.ArticleRepository;
 import com.filmdoms.community.comment.data.entity.Comment;
 import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.exception.ApplicationException;
+import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.file.data.entity.File;
 import com.filmdoms.community.file.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +58,7 @@ public class AccountService {
     private final ArticleRepository articleRepository;
     private final CommentRepository commentRepository;
     private final RedisUtil redisUtil;
+    private final DefaultProfileImage defaultProfileImage;
 
     @Transactional
     public LoginDto login(String email, String password) {
@@ -171,7 +173,7 @@ public class AccountService {
                 .nickname(requestDto.getNickname())
                 .email(requestDto.getEmail())
                 .role(AccountRole.USER)
-                .profileImage(getDefaultImage())
+                .profileImage(defaultProfileImage.getDefaultProfileImage())
                 .build();
 
         log.info("Account 엔티티 저장");
@@ -193,16 +195,6 @@ public class AccountService {
         redisUtil.deleteKey(requestDto.getEmailAuthUuid());
     }
 
-    // TODO: 프로필 기본 이미지 어떻게 처리할 지 상의 필요
-    private File getDefaultImage() {
-        return fileRepository.findById(1L).orElseGet(() -> fileRepository.save(
-                        File.builder()
-                                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
-                                .originalFileName("original_file_name")
-                                .build()
-                )
-        );
-    }
 
     public AccountResponseDto readAccount(AccountDto accountDto) {
 

--- a/src/main/java/com/filmdoms/community/config/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/filmdoms/community/config/oauth/CustomOAuthSuccessHandler.java
@@ -1,16 +1,17 @@
 package com.filmdoms.community.config.oauth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.filmdoms.community.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.account.data.DefaultProfileImage;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.constant.OAuthType;
 import com.filmdoms.community.account.data.dto.response.OAuthResponseDto;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.account.data.entity.Account;
-import com.filmdoms.community.exception.ApplicationException;
-import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.repository.RefreshTokenRepository;
+import com.filmdoms.community.config.jwt.JwtTokenProvider;
+import com.filmdoms.community.exception.ApplicationException;
+import com.filmdoms.community.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
+    private final DefaultProfileImage defaultProfileImage;
 
     protected void handle(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
@@ -112,6 +114,7 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                 .email(email)
                 .role(AccountRole.GUEST)
                 .isSocialLogin(true)
+                .profileImage(defaultProfileImage.getDefaultProfileImage())
                 .build();
         return accountRepository.save(account);
     }


### PR DESCRIPTION
기존에 프로필 이미지 생성이 여러곳에서 이루어 지고 있던점을 확인하였고, 통일하기 위해 의존성을 삭제하였지만
의존성을 삭제하니 매 회원가입시 마다 기본 프로필이 계속 생성되는 것을 확인하였습니다.
해결하기 위하여 DefaultProfileImage 클래스를 만들어 컴포넌트로 선언하고, 해당 컴포넌트에서 프로필 이미지를 가져오게끔 변경하였습니다.

향후에 기본 프로필 이미지를 변경한다거나, 기본 프로필 이미지가 여러개가 될 경우 해당 DefaultProfileImage 클래스에 선언 후 사용하면 프로필 이미지를 한번에 관리 할 수 있어 보입니다.

다만 이렇게 진행 할 시 기존에 Cascade type을 all로 지정되었던 것을 삭제하였습니다. 매번 생성되는 account 엔티티가 하나의 file엔티티를 가리키기 때문에 예외가 발생하였고 삭제하니 잘 동작하였습니다.