### PR TITLE
계정 삭제 로직 수정

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/constant/AccountStatus.java
+++ b/src/main/java/com/filmdoms/community/account/data/constant/AccountStatus.java
@@ -7,5 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AccountStatus {
     ACTIVE,
-    INACTIVE
+    INACTIVE,
+    DELETED
 }

--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -81,4 +81,8 @@ public class Account extends BaseTimeEntity {
         this.nickname = nickname;
         this.accountRole = AccountRole.USER;
     }
+
+    public void updateStatusToDeleted() {
+        this.accountStatus = AccountStatus.DELETED;
+    }
 }

--- a/src/main/java/com/filmdoms/community/account/service/TokenAuthenticationService.java
+++ b/src/main/java/com/filmdoms/community/account/service/TokenAuthenticationService.java
@@ -1,6 +1,7 @@
 package com.filmdoms.community.account.service;
 
 import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.exception.ApplicationException;
 import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
@@ -26,8 +27,12 @@ public class TokenAuthenticationService {
         } catch (NumberFormatException e) {
             throw new ApplicationException(ErrorCode.USER_NOT_FOUND);
         }
-        return accountRepository.findById(accountId)
-                .map(AccountDto::from)
+
+        Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        AccountService.checkAccountStatus(account);
+
+        return AccountDto.from(account);
     }
 }

--- a/src/main/java/com/filmdoms/community/config/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/filmdoms/community/config/oauth/CustomOAuthSuccessHandler.java
@@ -9,6 +9,7 @@ import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.repository.RefreshTokenRepository;
+import com.filmdoms.community.account.service.AccountService;
 import com.filmdoms.community.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.exception.ApplicationException;
 import com.filmdoms.community.exception.ErrorCode;
@@ -54,6 +55,7 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             Account account = accountRepository.findByEmail(email)
                     .orElseGet(() -> createGuestAccountWithEmail(email)); //가입된 이메일이 아닌 경우 GUEST 등급의 Account 생성
             checkSocialLoginAccount(account); //소셜 로그인 계정 여부 확인
+            AccountService.checkAccountStatus(account);
 
             String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(account.getId()));
             ResponseCookie refreshTokenCookie = resolveRefreshTokenCookieFromAccount(account);

--- a/src/main/java/com/filmdoms/community/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/exception/ErrorCode.java
@@ -48,7 +48,9 @@ public enum ErrorCode {
     ALREADY_UNREGISTERED_ANNOUNCE(HttpStatus.BAD_REQUEST,"이미 등록해제된 공지사항입니다"),
     INVALID_ANNOUNCE_ID(HttpStatus.BAD_REQUEST,"존재하지 않는 공지사항입니다"),
     INVALID_TAG(HttpStatus.BAD_REQUEST, "해당 카테고리에 존재하지 않는 태그입니다."),
-    SOCIAL_LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인에 실패했습니다.");
+    SOCIAL_LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인에 실패했습니다."),
+    INACTIVE_ACCOUNT(HttpStatus.BAD_REQUEST, "비활성화된 계정입니다."),
+    DELETED_ACCOUNT(HttpStatus.BAD_REQUEST, "삭제된 계정입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
계정 삭제 시 작성 글/댓글, 투표 등 연관 엔티티로 인해 삭제가 불가능한 문제가 있었습니다.
따라서 계정 삭제 요청 시 실제로 계정을 삭제하지 않고, 계정 상태를 DELETED로 변경한 뒤, 해당 계정으로 로그인과 인증이 불가능하도록 로직을 변경했습니다.
계정 정보를 언제 실제로 삭제할 것인지에 대한 논의가 필요해 보입니다.