### PR TITLE
게시글 삭제 API 작성

### DIFF
--- a/src/main/java/com/filmdoms/community/article/controller/ArticleController.java
+++ b/src/main/java/com/filmdoms/community/article/controller/ArticleController.java
@@ -62,6 +62,18 @@ public class ArticleController {
         return Response.success(dto);
     }
 
+    @PutMapping("/article/{category}/{articleId}")
+    public Response<Void> update(@PathVariable Category category, @PathVariable Long articleId, @AuthenticationPrincipal AccountDto accountDto) {
+
+        return Response.success();
+    }
+
+    @DeleteMapping("/article/{category}/{articleId}")
+    public Response<Void> delete(@PathVariable Category category, @PathVariable Long articleId, @AuthenticationPrincipal AccountDto accountDto) {
+        articleService.deleteArticle(category, articleId, accountDto);
+        return Response.success();
+    }
+
     @GetMapping("/article/init-data")
     public Response initData(@RequestParam(defaultValue = "10") int limit) {
         initService.makeArticleData(limit);

--- a/src/main/java/com/filmdoms/community/article/data/entity/extra/Critic.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/extra/Critic.java
@@ -25,7 +25,7 @@ public class Critic {
     private Article article;
 
     @JoinColumn(name = "file_id")
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private File mainImage;
 
     @Builder

--- a/src/main/java/com/filmdoms/community/article/data/entity/extra/FilmUniverse.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/extra/FilmUniverse.java
@@ -23,7 +23,7 @@ public class FilmUniverse {
     private Article article;
 
     @JoinColumn(name = "file_id")
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private File mainImage;
 
     private LocalDateTime startDate;

--- a/src/main/java/com/filmdoms/community/article/repository/CriticRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/CriticRepository.java
@@ -39,5 +39,8 @@ public interface CriticRepository extends JpaRepository<Critic, Long> {
             , countQuery = "SELECT count(c) from Critic c inner join c.article where c.article.tag =:tagId")
     Page<Critic> getCriticsByTag(@Param("tagId") Tag tag, Pageable pageable);
 
-
+    @Query("SELECT c FROM Critic c " +
+            "LEFT JOIN FETCH c.article " +
+            "WHERE c.article.id = :articleId")
+    Optional<Critic> findByArticleIdWithArticle(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/filmdoms/community/article/repository/FilmUniverseRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/FilmUniverseRepository.java
@@ -11,17 +11,22 @@ import java.util.Optional;
 
 public interface FilmUniverseRepository extends JpaRepository<FilmUniverse, Long> {
 
-    @Query("SELECT n FROM FilmUniverse n " +
-            "LEFT JOIN FETCH n.article " +
-            "LEFT JOIN FETCH n.article.author " +
-            "LEFT JOIN FETCH n.mainImage")
+    @Query("SELECT f FROM FilmUniverse f " +
+            "LEFT JOIN FETCH f.article " +
+            "LEFT JOIN FETCH f.article.author " +
+            "LEFT JOIN FETCH f.mainImage")
     List<FilmUniverse> findAllWithArticleAuthorMainImage(Pageable pageable);
-    @Query("SELECT n FROM FilmUniverse n " +
-            "LEFT JOIN FETCH n.article " +
-            "LEFT JOIN FETCH n.article.author.profileImage " +
-            "LEFT JOIN FETCH n.article.content " +
-            "WHERE n.article.id = :articleId")
+    @Query("SELECT f FROM FilmUniverse f " +
+            "LEFT JOIN FETCH f.article " +
+            "LEFT JOIN FETCH f.article.author.profileImage " +
+            "LEFT JOIN FETCH f.article.content " +
+            "WHERE f.article.id = :articleId")
     Optional<FilmUniverse> findByArticleIdWithArticleAuthorProfileImageContent(@Param("articleId") Long articleId);
 
     Optional<FilmUniverse> findByArticleId(Long articleId);
+
+    @Query("SELECT f FROM FilmUniverse f " +
+            "LEFT JOIN FETCH f.article " +
+            "WHERE f.article.id = :articleId")
+    Optional<FilmUniverse> findByArticleIdWithArticle(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/filmdoms/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/filmdoms/community/comment/repository/CommentRepository.java
@@ -1,10 +1,12 @@
 package com.filmdoms.community.comment.repository;
 
 import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.comment.data.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +27,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             countQuery = "SELECT COUNT(c) FROM Comment c " +
                     "WHERE c.author = :author")
     Page<Comment> findByAuthorWithArticle(@Param("author") Account author, Pageable pageable);
+
+    List<Comment> findByArticle(Article article);
 }

--- a/src/main/java/com/filmdoms/community/comment/repository/CommentVoteRepository.java
+++ b/src/main/java/com/filmdoms/community/comment/repository/CommentVoteRepository.java
@@ -1,11 +1,22 @@
 package com.filmdoms.community.comment.repository;
 
+import com.filmdoms.community.comment.data.entity.Comment;
 import com.filmdoms.community.comment.data.entity.CommentVote;
 import com.filmdoms.community.comment.data.entity.CommentVoteKey;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentVoteRepository extends JpaRepository<CommentVote, CommentVoteKey> {
 
     Optional<CommentVote> findByVoteKey(CommentVoteKey voteKey);
+
+    @Modifying
+    @Query("DELETE FROM CommentVote cv " +
+            "WHERE cv.voteKey.comment IN :comments")
+    void deleteByComments(@Param("comments") List<Comment> comments);
 }

--- a/src/main/java/com/filmdoms/community/comment/service/CommentService.java
+++ b/src/main/java/com/filmdoms/community/comment/service/CommentService.java
@@ -60,6 +60,11 @@ public class CommentService {
                 throw new ApplicationException(ErrorCode.INVALID_PARENT_COMMENT_ID);
             }
 
+            //최상위 댓글인지 확인
+            if (parentComment.getParentComment() != null) {
+                throw new ApplicationException(ErrorCode.INVALID_PARENT_COMMENT_ID);
+            }
+
             //부모 댓글이 INACTIVE, DELETED인 경우 댓글 생성 불가능하게 할지 결정 필요
         }
 

--- a/src/main/java/com/filmdoms/community/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/exception/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "해당 유저는 요청을 수행할 권한이 없습니다."),
+    INVALID_PERMISSION(HttpStatus.FORBIDDEN, "해당 유저는 요청을 수행할 권한이 없습니다."),
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류가 발생했습니다."),
     AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "토큰이 첨부되지 않았습니다."),

--- a/src/main/java/com/filmdoms/community/vote/repository/VoteRepository.java
+++ b/src/main/java/com/filmdoms/community/vote/repository/VoteRepository.java
@@ -1,11 +1,22 @@
 package com.filmdoms.community.vote.repository;
 
+import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.vote.data.entity.Vote;
 import com.filmdoms.community.vote.data.entity.VoteKey;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<Vote, VoteKey> {
 
     Optional<Vote> findByVoteKey(VoteKey voteKey);
+
+    @Modifying
+    @Query("DELETE FROM Vote v " +
+            "WHERE v.voteKey.article = :article")
+    void deleteByArticle(@Param("article") Article article);
 }

--- a/src/test/java/com/filmdoms/community/testentityprovider/TestCommentProvider.java
+++ b/src/test/java/com/filmdoms/community/testentityprovider/TestCommentProvider.java
@@ -1,0 +1,24 @@
+package com.filmdoms.community.testentityprovider;
+
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.comment.data.entity.Comment;
+
+public class TestCommentProvider {
+
+    private static int count;
+
+    public static Comment get(Account author, Article article, Comment parentComment) {
+        count++;
+        Comment comment = Comment.builder()
+                .isManagerComment(false)
+                .content("test_comment_content_" + count)
+                .author(author)
+                .article(article)
+                .parentComment(parentComment)
+                .build();
+
+        return comment;
+    }
+}


### PR DESCRIPTION
게시글 삭제 API를 작성했고, API 명세 업데이트 했습니다.

Article 엔티티의 경우 연관 관계가 많아서 제약조건 예외가 발생하지 않도록 외래키를 가진 엔티티부터 차례대로 삭제했습니다.

현재 Content 객체의 FileContent 종속성 때문에 추가 쿼리가 나가고 있습니다. 게시글과 게시글 이미지를 매핑하는 방법이 게시글 내용에 이미지 URL을 포함시키는 방식으로 결정된 것이라면, FileContent 관련 모듈을 아예 삭제해서 쿼리를 최적화하는 것이 좋아 보입니다.