### PR TITLE
공지사항, 프로필응답 부분 코드 수정(fix)

### DIFF
--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -7,10 +7,7 @@ import com.filmdoms.community.account.data.dto.request.*;
 import com.filmdoms.community.account.data.dto.request.profile.UpdateFavoriteMoviesDto;
 import com.filmdoms.community.account.data.dto.request.profile.UpdateNicknameRequestDto;
 import com.filmdoms.community.account.data.dto.request.profile.UpdateProfileImageRequestDto;
-import com.filmdoms.community.account.data.dto.response.AccessTokenResponseDto;
-import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
-import com.filmdoms.community.account.data.dto.response.CheckDuplicateResponseDto;
-import com.filmdoms.community.account.data.dto.response.Response;
+import com.filmdoms.community.account.data.dto.response.*;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileArticleResponseDto;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileCommentResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
@@ -182,7 +179,7 @@ public class AccountController {
 
     @GetMapping("/profile/{accountId}")
     public Response getUserAccount(@PathVariable Long accountId) {
-        AccountResponseDto accountResponseDto = accountService.readAccount(accountId);
+        PublicAccountResponseDto accountResponseDto = accountService.readAccount(accountId);
         return Response.success(accountResponseDto);
     }
 

--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -1,6 +1,5 @@
 package com.filmdoms.community.account.controller;
 
-import com.filmdoms.community.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.account.data.constant.AccountRole;
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.dto.LoginDto;
@@ -17,6 +16,7 @@ import com.filmdoms.community.account.data.dto.response.profile.ProfileCommentRe
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.service.AccountService;
+import com.filmdoms.community.config.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -125,14 +125,6 @@ public class AccountController {
         return Response.success(accountService.readAccount(accountDto));
     }
 
-//    @PutMapping("/profile")
-//    public Response<Void> updateProfile(
-//            @RequestBody UpdateProfileRequestDto requestDto,
-//            @AuthenticationPrincipal AccountDto accountDto) {
-//        accountService.updateAccountProfile(requestDto, accountDto);
-//        return Response.success();
-//    }
-
     @PutMapping("/profile/nickname")
     public Response<Void> updateNickname(
             @RequestBody UpdateNicknameRequestDto requestDto,
@@ -186,6 +178,12 @@ public class AccountController {
             @AuthenticationPrincipal AccountDto accountDto) {
         accountService.deleteAccount(requestDto, accountDto);
         return Response.success();
+    }
+
+    @GetMapping("/profile/{accountId}")
+    public Response getUserAccount(@PathVariable Long accountId) {
+        AccountResponseDto accountResponseDto = accountService.readAccount(accountId);
+        return Response.success(accountResponseDto);
     }
 
     private boolean duplicateExistsInMovieNameList(List<String> favoriteMovies) {

--- a/src/main/java/com/filmdoms/community/account/data/dto/response/PublicAccountResponseDto.java
+++ b/src/main/java/com/filmdoms/community/account/data/dto/response/PublicAccountResponseDto.java
@@ -1,0 +1,47 @@
+package com.filmdoms.community.account.data.dto.response;
+
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.constant.AccountStatus;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.data.entity.FavoriteMovie;
+import com.filmdoms.community.account.data.entity.Movie;
+import com.filmdoms.community.file.data.dto.response.FileResponseDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PublicAccountResponseDto {
+
+    private Long id;
+    private Long registeredAt;
+    private String nickname;
+    private AccountRole accountRole;
+    private AccountStatus accountStatus;
+    private boolean isSocialLogin;
+    private FileResponseDto profileImage;
+    private List<String> favoriteMovies;
+
+    private PublicAccountResponseDto(Account account, List<FavoriteMovie> favoriteMovies) {
+        this.id = account.getId();
+        this.nickname = account.getNickname();
+        this.accountRole = account.getAccountRole();
+        this.accountStatus = account.getAccountStatus();
+        this.isSocialLogin = account.isSocialLogin();
+        this.profileImage = FileResponseDto.from(account.getProfileImage());
+        this.registeredAt = ZonedDateTime.of(account.getDateCreated(), ZoneId.systemDefault()).toInstant().toEpochMilli();
+        this.favoriteMovies = favoriteMovies.stream()
+                .map(FavoriteMovie::getMovie)
+                .map(Movie::getName)
+                .collect(Collectors.toList());
+    }
+
+    public static PublicAccountResponseDto from(Account account, List<FavoriteMovie> favoriteMovies) {
+        return new PublicAccountResponseDto(account, favoriteMovies);
+    }
+}

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -10,6 +10,7 @@ import com.filmdoms.community.account.data.dto.request.profile.UpdateNicknameReq
 import com.filmdoms.community.account.data.dto.request.profile.UpdateProfileImageRequestDto;
 import com.filmdoms.community.account.data.dto.response.AccessTokenResponseDto;
 import com.filmdoms.community.account.data.dto.response.AccountResponseDto;
+import com.filmdoms.community.account.data.dto.response.PublicAccountResponseDto;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileArticleResponseDto;
 import com.filmdoms.community.account.data.dto.response.profile.ProfileCommentResponseDto;
 import com.filmdoms.community.account.data.entity.Account;
@@ -208,13 +209,13 @@ public class AccountService {
         return AccountResponseDto.from(account, favoriteMovies);
     }
 
-    public AccountResponseDto readAccount(Long accountId) {
+    public PublicAccountResponseDto readAccount(Long accountId) {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
         List<FavoriteMovie> favoriteMovies = favoriteMovieRepository.findAllByAccount(account);
 
-        return AccountResponseDto.from(account, favoriteMovies);
+        return PublicAccountResponseDto.from(account, favoriteMovies);
     }
 
     @Transactional

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -208,6 +208,15 @@ public class AccountService {
         return AccountResponseDto.from(account, favoriteMovies);
     }
 
+    public AccountResponseDto readAccount(Long accountId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        List<FavoriteMovie> favoriteMovies = favoriteMovieRepository.findAllByAccount(account);
+
+        return AccountResponseDto.from(account, favoriteMovies);
+    }
+
     @Transactional
     public void updateNickname(UpdateNicknameRequestDto dto, AccountDto accountDto) {
         Account account = accountRepository.findByEmail(accountDto.getEmail())

--- a/src/main/java/com/filmdoms/community/article/controller/AnnounceController.java
+++ b/src/main/java/com/filmdoms/community/article/controller/AnnounceController.java
@@ -32,26 +32,14 @@ public class AnnounceController {
 
     @PostMapping("/article/announce")
     public Response registerAnnounce(@RequestBody AnnounceRegisterDto dto, @AuthenticationPrincipal AccountDto accountDto) {
-        checkArticleExistAndAuthority(dto, accountDto); // 실제로 등록된 게시글이 있는지와, 요청한 유저의 권한을 확인합니다.
-
         return announceService.registerAnnounce(dto.getArticleId());
     }
 
     @DeleteMapping("/article/announce")
     public Response unregisterAnnounce(@RequestBody AnnounceRegisterDto dto, @AuthenticationPrincipal AccountDto accountDto) {
-        checkArticleExistAndAuthority(dto, accountDto);
-
         return announceService.unregisterAnnounce(dto.getArticleId());
-
     }
 
-    private void checkArticleExistAndAuthority(AnnounceRegisterDto stateChangeDto, AccountDto accountDto) {
-        Optional<Article> optionalArticle = articleRepository.findById(stateChangeDto.getArticleId());
-        if (optionalArticle.isEmpty())
-            throw new ApplicationException(ErrorCode.INVALID_ARTICLE_ID);
-        if (accountDto.getAccountRole() != AccountRole.ADMIN)
-            throw new ApplicationException(ErrorCode.AUTHORIZATION_ERROR);
-    }
 
     @GetMapping("/article/announce")
     public Response getAllAnnounceArticles(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/src/main/java/com/filmdoms/community/article/service/AnnounceService.java
+++ b/src/main/java/com/filmdoms/community/article/service/AnnounceService.java
@@ -27,6 +27,10 @@ public class AnnounceService {
 
     public Response registerAnnounce(Long articleId) {
 
+        Optional<Article> optionalArticle = articleRepository.findById(articleId);
+        if (optionalArticle.isEmpty())
+            throw new ApplicationException(ErrorCode.INVALID_ARTICLE_ID);
+
         Optional<Announce> optionalAnnounce = announceRepository.findAnnounceByArticleId(articleId);
         if (optionalAnnounce.isPresent())
             throw new ApplicationException(ErrorCode.ALREADY_REGISTERED_ANNOUNCE);
@@ -42,6 +46,10 @@ public class AnnounceService {
     }
 
     public Response unregisterAnnounce(Long articleId) {
+
+        Optional<Article> optionalArticle = articleRepository.findById(articleId);
+        if (optionalArticle.isEmpty())
+            throw new ApplicationException(ErrorCode.INVALID_ARTICLE_ID);
 
         Optional<Announce> optionalAnnounce = announceRepository.findAnnounceByArticleId(articleId);
         if (optionalAnnounce.isEmpty())

--- a/src/main/java/com/filmdoms/community/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/**").hasAnyRole("ADMIN", "USER")
                         .requestMatchers(HttpMethod.PUT, "/api/v1/**").hasAnyRole("ADMIN", "USER")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/**").hasAnyRole("ADMIN", "USER")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/article/announce").hasRole("ADMIN")
                         .anyRequest().permitAll())
 
                 // H2 DB 사용을 위해, x-frame-options 동일 출처 허용


### PR DESCRIPTION
총 3가지를 테스트 하였고 2가지를 수정하였습니다.
좋아요 기능은 테스트 시 잘 동작하였기 때문에 따로 수정하지 않았습니다.

1. 마이 페이지 외에 프로필 조회가 필요하기에, 비회원도 열람 가능한 api를 생성하였습니다.
이메일은 민감한 정보이기 때문에 보여지지 않는 것이 맞고 
향후 마이 페이지와, 실제 다른 사람들이 보는 프로필에 차이가 있어야 될 경우도 있기 때문입니다.
따라서 기존 Dto를 사용하지 않고 새로운 PublicAccountResponseDto 를 만들어 이메일 항목을 지웠습니다.

2. 공지사항 컨트롤러에서 원래 권한체크와, 게시글 유효성을 검증했는데, 생각해보니 권한 체크는 Config설정에서 가능해 옮겼고, 유효성 검증은 서비스 코드 쪽으로 수정하였습니다.

