### PR TITLE
조회수 반영 로직 추가

### DIFF
--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -73,4 +73,8 @@ public class Article extends BaseTimeEntity {
     public int removeVote() {
         return --voteCount;
     }
+
+    public int addView() {
+        return ++view;
+    }
 }

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -133,6 +133,7 @@ public class ArticleService {
 
             List<File> images = fileRepository.findByArticleId(articleId);
             boolean isVoted = getArticleVoteStatus(accountDto, article);
+            article.addView();
 
             return ArticleDetailResponseDto.from(article, images, isVoted);
 
@@ -141,6 +142,7 @@ public class ArticleService {
 
             List<File> images = fileRepository.findByArticleId(articleId);
             boolean isVoted = getArticleVoteStatus(accountDto, notice.getArticle());
+            notice.getArticle().addView();
 
             return FilmUniverseDetailResponseDto.from(notice, images, isVoted);
         }


### PR DESCRIPTION
Article 엔티티에 조회수 추가 메서드를 추가하고, 게시글 상세 보기 로직에 조회수 추가 로직을 더했습니다.

데이터가 수정되는 로직이지만, 조회수는 다른 데이터에 비해 일관성이 중요한 데이터가 아닌데,
@Transactional 을 붙이면 성능 저하가 일어나기 때문에 일부러 붙이지 않았습니다.