### PR TITLE
회원 탈퇴 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	compileOnly 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok:1.18.22'
+    compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 // JWT 관련 의존성
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -42,6 +42,8 @@ public class Account extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus = AccountStatus.ACTIVE;
 
+    private LocalDateTime deleteRegisteredDate = null;
+
     @Column(name = "login_fail_count")
     private int loginFailCount = 0;
 
@@ -82,7 +84,8 @@ public class Account extends BaseTimeEntity {
         this.accountRole = AccountRole.USER;
     }
 
-    public void updateStatusToDeleted() {
+    public void updateStatusToDeleted(LocalDateTime localDateTime) {
         this.accountStatus = AccountStatus.DELETED;
+        this.deleteRegisteredDate = localDateTime;
     }
 }

--- a/src/main/java/com/filmdoms/community/account/repository/AccountRepository.java
+++ b/src/main/java/com/filmdoms/community/account/repository/AccountRepository.java
@@ -1,10 +1,12 @@
 package com.filmdoms.community.account.repository;
 
 import com.filmdoms.community.account.data.entity.Account;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
@@ -22,4 +24,9 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             "LEFT JOIN FETCH a.profileImage " +
             "WHERE a.email = :email")
     Optional<Account> findByEmailWithImage(@Param("email") String email);
+
+    @Query("SELECT a FROM Account a " +
+            "where a.accountStatus = 'DELETED' ")
+    Optional<List<Account>> findDeletedAccounts();
+
 }

--- a/src/main/java/com/filmdoms/community/account/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/filmdoms/community/account/scheduler/SchedulerConfig.java
@@ -1,0 +1,40 @@
+package com.filmdoms.community.account.scheduler;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+@EnableScheduling
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class SchedulerConfig {
+
+    private final AccountRepository accountRepository;
+    private final AccountService accountService;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void accountDeleteScheduler() {
+        Optional<List<Account>> deletedAccounts = accountRepository.findDeletedAccounts();
+
+        if (deletedAccounts.isPresent()) {
+            List<Account> deletedList = deletedAccounts.get();
+            deletedList.stream().filter(account -> {
+                long daysBetween = ChronoUnit.DAYS.between(account.getDeleteRegisteredDate(), LocalDateTime.now());
+                return daysBetween >= 7;
+            }).forEach(account -> accountService.deleteExpiredAccount(account));
+        }
+
+
+    }
+}

--- a/src/main/java/com/filmdoms/community/article/data/constant/PostStatus.java
+++ b/src/main/java/com/filmdoms/community/article/data/constant/PostStatus.java
@@ -1,5 +1,5 @@
 package com.filmdoms.community.article.data.constant;
 
 public enum PostStatus {
-    ACTIVE, INACTIVE
+    ACTIVE, INACTIVE, DELETED;
 }

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/detail/ArticleDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/detail/ArticleDetailResponseDto.java
@@ -2,17 +2,13 @@ package com.filmdoms.community.article.data.dto.response.detail;
 
 import com.filmdoms.community.account.data.dto.response.DetailPageAccountResponseDto;
 import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.PostStatus;
 import com.filmdoms.community.article.data.constant.Tag;
 import com.filmdoms.community.article.data.entity.Article;
-import com.filmdoms.community.article.data.constant.PostStatus;
-import com.filmdoms.community.file.data.dto.response.FileResponseDto;
-import com.filmdoms.community.file.data.entity.File;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.Getter;
 
-import java.util.Comparator;
-import java.util.List;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 /**
  * 영화, 비평 게시판의 게시글 상세 페이지 응답 DTO
@@ -32,9 +28,8 @@ public class ArticleDetailResponseDto {
     private long createdAt;
     private long updatedAt;
     private DetailPageAccountResponseDto author;
-    private List<FileResponseDto> images;
 
-    protected ArticleDetailResponseDto(Article article, List<File> images, boolean isVoted) {
+    protected ArticleDetailResponseDto(Article article, boolean isVoted) {
         this.id = article.getId();
         this.category = article.getCategory();
         this.tag = article.getTag();
@@ -47,10 +42,9 @@ public class ArticleDetailResponseDto {
         this.createdAt = ZonedDateTime.of(article.getDateCreated(), ZoneId.systemDefault()).toInstant().toEpochMilli();
         this.updatedAt = ZonedDateTime.of(article.getDateLastModified(), ZoneId.systemDefault()).toInstant().toEpochMilli();
         this.author = DetailPageAccountResponseDto.from(article.getAuthor());
-        this.images = images.stream().sorted(Comparator.comparing(File::getId)).map(FileResponseDto::from).toList(); //id로 정렬한 뒤 DTO 변환
     }
 
-    public static ArticleDetailResponseDto from(Article article, List<File> images, boolean isVoted) {
-        return new ArticleDetailResponseDto(article, images, isVoted);
+    public static ArticleDetailResponseDto from(Article article, boolean isVoted) {
+        return new ArticleDetailResponseDto(article, isVoted);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/detail/FilmUniverseDetailResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/detail/FilmUniverseDetailResponseDto.java
@@ -1,11 +1,9 @@
 package com.filmdoms.community.article.data.dto.response.detail;
 
 import com.filmdoms.community.article.data.entity.extra.FilmUniverse;
-import com.filmdoms.community.file.data.entity.File;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 공지 게시판의 게시글 상세 페이지 응답 DTO
@@ -16,13 +14,13 @@ public class FilmUniverseDetailResponseDto extends ArticleDetailResponseDto {
     private LocalDateTime startAt;
     private LocalDateTime endAt;
 
-    private FilmUniverseDetailResponseDto(FilmUniverse filmUniverse, List<File> images, boolean isVoted) {
-        super(filmUniverse.getArticle(), images, isVoted);
+    private FilmUniverseDetailResponseDto(FilmUniverse filmUniverse, boolean isVoted) {
+        super(filmUniverse.getArticle(), isVoted);
         this.startAt = filmUniverse.getStartDate();
         this.endAt = filmUniverse.getEndDate();
     }
 
-    public static FilmUniverseDetailResponseDto from(FilmUniverse filmUniverse, List<File> images, boolean isVoted) {
-        return new FilmUniverseDetailResponseDto(filmUniverse, images, isVoted);
+    public static FilmUniverseDetailResponseDto from(FilmUniverse filmUniverse, boolean isVoted) {
+        return new FilmUniverseDetailResponseDto(filmUniverse, isVoted);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -73,4 +73,12 @@ public class Article extends BaseTimeEntity {
     public int removeVote() {
         return --voteCount;
     }
+
+    public void changePostStatusToDeleted() {
+        this.status = PostStatus.DELETED;
+    }
+
+    public void changePostStatusToActive() {
+        this.status = PostStatus.ACTIVE;
+    }
 }

--- a/src/main/java/com/filmdoms/community/article/data/entity/Content.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Content.java
@@ -1,13 +1,9 @@
 package com.filmdoms.community.article.data.entity;
 
-import com.filmdoms.community.file.data.entity.FileContent;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,9 +16,6 @@ public class Content {
 
     @Column(name = "content", length = 10000)
     private String content;
-
-    @OneToMany(mappedBy = "content", cascade = CascadeType.REMOVE)
-    private Set<FileContent> fileContents = new HashSet<>();
 
     Content(String content) {
         this.content = content;

--- a/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
@@ -14,52 +14,55 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    List<Article> findByCategory(Category category, Pageable pageable);
+    @Query("Select a from Article a where a.category =:category and a.status ='ACTIVE'")
+    List<Article> findByCategory(@Param("category")Category category, Pageable pageable);
 
     //JPA 기본 제공 findAll 메서드는 페이지 객체를 반환하므로 필요 없는 count 쿼리가 나감 -> 리스트를 반환하는 메서드를 따로 만듦
-    @Query("SELECT a FROM Article a")
+    @Query("SELECT a FROM Article a where a.status = 'ACTIVE'")
     List<Article> findAllReturnList(Pageable pageable);
 
     @Query("SELECT a FROM Article a " +
             "LEFT JOIN FETCH a.author.profileImage " +
             "LEFT JOIN FETCH a.content " +
-            "WHERE a.id = :articleId")
+            "WHERE a.id = :articleId and a.status ='ACTIVE' ")
     Optional<Article> findByIdWithAuthorProfileImageContent(@Param("articleId") Long articleId);
 
     // 게시판 리스트 페이지 조회
-    @Query(value = "SELECT a from Article a inner join fetch a.author join fetch a.author.profileImage where a.category =:categoryId"
-            , countQuery = "SELECT count(a) from Article a where a.category =: categoryId")
+    @Query(value = "SELECT a from Article a inner join fetch a.author join fetch a.author.profileImage where a.category =:categoryId and a.status = 'ACTIVE'"
+            , countQuery = "SELECT count(a) from Article a where a.category =: categoryId and a.status = 'ACTIVE'")
     Page<Article> findArticlesByCategory(@Param("categoryId") Category category, Pageable pageable);
 
     // 게시판 리스트 페이지에서 태그로 필터링
-    @Query(value = "SELECT a from Article a inner join fetch a.author join fetch a.author.profileImage where a.category =:categoryId and a.tag =:tagId"
-            , countQuery = "SELECT count(a) from Article a where a.category =: categoryId and a.tag =: tagId")
+    @Query(value = "SELECT a from Article a inner join fetch a.author join fetch a.author.profileImage where a.category =:categoryId and a.tag =:tagId and a.status = 'ACTIVE'"
+            , countQuery = "SELECT count(a) from Article a where a.category =: categoryId and a.tag =: tagId and a.status='ACTIVE'")
     Page<Article> findArticlesByCategoryAndTag(@Param("categoryId") Category category, @Param("tagId") Tag tag, Pageable pageable);
 
     // (Recent) 최근 게시물 조회
-    @Query(value = "SELECT a from Article a inner join fetch  a.author join fetch  a.author.profileImage"
-            , countQuery = "SELECT count(a) FROM  Article a")
+    @Query(value = "SELECT a from Article a inner join fetch  a.author join fetch  a.author.profileImage where a.status = 'ACTIVE'"
+            , countQuery = "SELECT count(a) FROM  Article a where a.status = 'ACTIVE'")
     Page<Article> getAllArticles(Pageable pageable);
 
     // (Recent) 최근 게시물을 태그로 필터링
-    @Query(value = "SELECT a from Article a inner join fetch  a.author join fetch  a.author.profileImage where a.tag =:tagId"
-            , countQuery = "SELECT count(a) FROM  Article a where a.tag =:tagId")
+    @Query(value = "SELECT a from Article a inner join fetch  a.author join fetch  a.author.profileImage where a.tag =:tagId and a.status = 'ACTIVE'"
+            , countQuery = "SELECT count(a) FROM  Article a where a.tag =:tagId and a.status = 'ACTIVE'")
     Page<Article> getAllArticlesByTag(@Param("tagId") Tag tag, Pageable pageable);
 
     // 인기 게시글 조회
-    @Query(value = "SELECT a from Article a inner join fetch a.author order by a.voteCount desc limit 5")
+    @Query(value = "SELECT a from Article a inner join fetch a.author where a.status = 'ACTIVE' order by a.voteCount desc limit 5")
     List<Article> getTop5Articles();
 
     // 제목 + 내용 으로 조회
     @Query(value = "SELECT a from Article a inner join fetch a.author inner join fetch a.author.profileImage inner join fetch a.content " +
-            "where a.category =:categoryId and (a.title like %:keyword% or a.content.content like %:keyword%)"
-            , countQuery = "SELECT count(a) from Article a inner join a.content where a.category =:categoryId and (a.title like %:keyword% or a.content.content like %:keyword%) ")
+            "where a.category =:categoryId and (a.title like %:keyword% or a.content.content like %:keyword%)and a.status = 'ACTIVE'"
+            , countQuery = "SELECT count(a) from Article a inner join a.content where a.category =:categoryId and (a.title like %:keyword% or a.content.content like %:keyword%) and a.status = 'ACTIVE' ")
     Page<Article> findArticlesByKeyword(@Param("categoryId") Category category, @Param("keyword") String keyword, Pageable pageable);
 
     // 글작성자로 조회
-    @Query(value = "SELECT a from Article a inner join fetch a.author join fetch a.author.profileImage where a.category =:categoryId and a.author.nickname =:nickname"
-            , countQuery = "SELECT count(a) from Article a inner join a.author where a.category =:categoryId and a.author.nickname =:nickname")
+    @Query(value = "SELECT a from Article a inner join fetch a.author join fetch a.author.profileImage where a.category =:categoryId and a.author.nickname =:nickname and a.status = 'ACTIVE'"
+            , countQuery = "SELECT count(a) from Article a inner join a.author where a.category =:categoryId and a.author.nickname =:nickname and a.status = 'ACTIVE'")
     Page<Article> findArticlesByNickname(@Param("categoryId") Category category, @Param("nickname") String nickname, Pageable pageable);
 
     Page<Article> findByAuthor(Account author, Pageable pageable);
+
+    List<Article> findByAuthor(Account account);
 }

--- a/src/main/java/com/filmdoms/community/article/repository/CriticRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/CriticRepository.java
@@ -18,7 +18,7 @@ public interface CriticRepository extends JpaRepository<Critic, Long> {
             "LEFT JOIN FETCH c.article " +
             "LEFT JOIN FETCH c.article.author " +
             "LEFT JOIN FETCH c.mainImage " +
-            "LEFT JOIN FETCH c.article.content")
+            "LEFT JOIN FETCH c.article.content where c.article.status = 'ACTIVE'")
     List<Critic> findAllWithArticleAuthorMainImageContent(Pageable pageable);
 
     Optional<Critic> findByArticleId(Long articleId);
@@ -27,16 +27,16 @@ public interface CriticRepository extends JpaRepository<Critic, Long> {
             "LEFT JOIN FETCH c.article " +
             "LEFT JOIN FETCH c.article.author " +
             "LEFT JOIN FETCH c.mainImage " +
-            "LEFT JOIN FETCH c.article.content"
-            , countQuery = "select count(c) from Critic c")
+            "LEFT JOIN FETCH c.article.content where c.article.status = 'ACTIVE'"
+            , countQuery = "select count(c) from Critic c where c.article.status = 'ACTIVE'")
     Page<Critic> getCritics(Pageable pageable);
 
     @Query(value = "SELECT c FROM Critic c " +
             "LEFT JOIN FETCH c.article " +
             "LEFT JOIN FETCH c.article.author " +
             "LEFT JOIN FETCH c.mainImage " +
-            "LEFT JOIN FETCH c.article.content where c.article.tag =:tagId"
-            , countQuery = "SELECT count(c) from Critic c inner join c.article where c.article.tag =:tagId")
+            "LEFT JOIN FETCH c.article.content where c.article.tag =:tagId and c.article.status = 'ACTIVE'"
+            , countQuery = "SELECT count(c) from Critic c inner join c.article where c.article.tag =:tagId and c.article.status = 'ACTIVE'")
     Page<Critic> getCriticsByTag(@Param("tagId") Tag tag, Pageable pageable);
 
     @Query("SELECT c FROM Critic c " +

--- a/src/main/java/com/filmdoms/community/article/repository/FilmUniverseRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/FilmUniverseRepository.java
@@ -14,13 +14,13 @@ public interface FilmUniverseRepository extends JpaRepository<FilmUniverse, Long
     @Query("SELECT f FROM FilmUniverse f " +
             "LEFT JOIN FETCH f.article " +
             "LEFT JOIN FETCH f.article.author " +
-            "LEFT JOIN FETCH f.mainImage")
+            "LEFT JOIN FETCH f.mainImage where f.article.status ='ACTIVE'")
     List<FilmUniverse> findAllWithArticleAuthorMainImage(Pageable pageable);
     @Query("SELECT f FROM FilmUniverse f " +
             "LEFT JOIN FETCH f.article " +
             "LEFT JOIN FETCH f.article.author.profileImage " +
             "LEFT JOIN FETCH f.article.content " +
-            "WHERE f.article.id = :articleId")
+            "WHERE f.article.id = :articleId and f.article.status = 'ACTIVE'")
     Optional<FilmUniverse> findByArticleIdWithArticleAuthorProfileImageContent(@Param("articleId") Long articleId);
 
     Optional<FilmUniverse> findByArticleId(Long articleId);

--- a/src/main/java/com/filmdoms/community/article/service/ArticleService.java
+++ b/src/main/java/com/filmdoms/community/article/service/ArticleService.java
@@ -2,11 +2,6 @@ package com.filmdoms.community.article.service;
 
 import com.filmdoms.community.account.data.dto.AccountDto;
 import com.filmdoms.community.account.data.entity.Account;
-import com.filmdoms.community.comment.data.entity.Comment;
-import com.filmdoms.community.comment.repository.CommentRepository;
-import com.filmdoms.community.comment.repository.CommentVoteRepository;
-import com.filmdoms.community.exception.ApplicationException;
-import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.article.data.constant.Category;
 import com.filmdoms.community.article.data.constant.Tag;
@@ -25,10 +20,14 @@ import com.filmdoms.community.article.data.dto.response.trending.TopFiveArticleR
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.article.data.entity.extra.Critic;
 import com.filmdoms.community.article.data.entity.extra.FilmUniverse;
-import com.filmdoms.community.article.repository.AnnounceRepository;
 import com.filmdoms.community.article.repository.ArticleRepository;
 import com.filmdoms.community.article.repository.CriticRepository;
 import com.filmdoms.community.article.repository.FilmUniverseRepository;
+import com.filmdoms.community.comment.data.entity.Comment;
+import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.comment.repository.CommentVoteRepository;
+import com.filmdoms.community.exception.ApplicationException;
+import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.file.data.entity.File;
 import com.filmdoms.community.file.repository.FileRepository;
 import com.filmdoms.community.vote.data.entity.VoteKey;
@@ -136,18 +135,16 @@ public class ArticleService {
                 throw new ApplicationException(ErrorCode.INVALID_ARTICLE_ID); //해당 카테고리에는 요청으로 온 id의 Article이 없으므로 게시물 id 관련 오류가 발생
             }
 
-            List<File> images = fileRepository.findByArticleId(articleId);
             boolean isVoted = getArticleVoteStatus(accountDto, article);
 
-            return ArticleDetailResponseDto.from(article, images, isVoted);
+            return ArticleDetailResponseDto.from(article, isVoted);
 
         } else if (category == Category.FILM_UNIVERSE) { //총 3번의 쿼리가 나감
             FilmUniverse notice = filmUniverseRepository.findByArticleIdWithArticleAuthorProfileImageContent(articleId).orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_ARTICLE_ID));
 
-            List<File> images = fileRepository.findByArticleId(articleId);
             boolean isVoted = getArticleVoteStatus(accountDto, notice.getArticle());
 
-            return FilmUniverseDetailResponseDto.from(notice, images, isVoted);
+            return FilmUniverseDetailResponseDto.from(notice, isVoted);
         }
 
         throw new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND);

--- a/src/main/java/com/filmdoms/community/comment/data/entity/Comment.java
+++ b/src/main/java/com/filmdoms/community/comment/data/entity/Comment.java
@@ -73,6 +73,8 @@ public class Comment extends BaseTimeEntity {
         this.status = CommentStatus.DELETED;
     }
 
+    public void changeStatusToActive() { this.status = CommentStatus.ACTIVE; }
+
     public int removeVote() {
         return --voteCount;
     }

--- a/src/main/java/com/filmdoms/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/filmdoms/community/comment/repository/CommentRepository.java
@@ -6,7 +6,6 @@ import com.filmdoms.community.comment.data.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,4 +28,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByAuthorWithArticle(@Param("author") Account author, Pageable pageable);
 
     List<Comment> findByArticle(Article article);
+    List<Comment> findByAuthor(Account account);
 }

--- a/src/main/java/com/filmdoms/community/file/repository/FileRepository.java
+++ b/src/main/java/com/filmdoms/community/file/repository/FileRepository.java
@@ -2,16 +2,8 @@ package com.filmdoms.community.file.repository;
 
 import com.filmdoms.community.file.data.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface FileRepository extends JpaRepository<File, Long> {
 
-    @Query("SELECT f FROM Article a " +
-            "JOIN a.content.fileContents fc " +
-            "JOIN fc.file f " +
-            "WHERE a.id = :articleId")
-    List<File> findByArticleId(@Param("articleId") Long articleId);
+
 }

--- a/src/test/java/com/filmdoms/community/account/scheduler/SchedulerConfigTest.java
+++ b/src/test/java/com/filmdoms/community/account/scheduler/SchedulerConfigTest.java
@@ -1,0 +1,131 @@
+package com.filmdoms.community.account.scheduler;
+
+import com.filmdoms.community.account.data.DefaultProfileImage;
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
+import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.data.entity.FavoriteMovie;
+import com.filmdoms.community.account.data.entity.Movie;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.repository.FavoriteMovieRepository;
+import com.filmdoms.community.account.repository.MovieRepository;
+import com.filmdoms.community.account.service.AccountService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Slf4j
+class SchedulerConfigTest {
+
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private AccountService accountService;
+    @Autowired
+    private DefaultProfileImage defaultProfileImage;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private MovieRepository movieRepository;
+    @Autowired
+    private FavoriteMovieRepository favoriteMovieRepository;
+
+    private List<Movie> findOrCreateFavoriteMovies(List<String> movieNames) {
+
+        log.info("기존 영화 엔티티 호출");
+        List<Movie> existingMovies = movieRepository.findAllByNames(movieNames);
+
+        log.info("영화 엔티티 이름 추출");
+        Set<String> existingMovieNames = existingMovies.stream()
+                .map(Movie::getName)
+                .collect(Collectors.toSet());
+
+        log.info("새 영화 엔티티 생성");
+        List<Movie> newMovies = movieNames.stream()
+                .filter(name -> !existingMovieNames.contains(name))
+                .map(Movie::new)
+                .toList();
+
+        log.info("새 영화 엔티티 저장");
+        // JPA는 Id 생성을 AutoIncrement로 지정하면 벌크 insert를 수행할 수 없다. 어쩔 수 없이 쿼리 N개 발생.
+        List<Movie> savedMovies = movieRepository.saveAll(newMovies);
+
+        return Stream.concat(existingMovies.stream(), savedMovies.stream()).toList();
+    }
+
+
+    private Account getAccount() {
+        List<String> favMovie = List.of("토르", "스파이더맨", "영화123");
+        JoinRequestDto requestDto = new JoinRequestDto("test@naver.com", "pass", "nickname1223", favMovie, "testetmailuuid");
+
+        log.info("Account 엔티티 생성");
+        Account newAccount = Account.builder()
+                //.username(requestDto.getUsername())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .nickname(requestDto.getNickname())
+                .email(requestDto.getEmail())
+                .role(AccountRole.USER)
+                .profileImage(defaultProfileImage.getDefaultProfileImage())
+                .build();
+
+        log.info("Account 엔티티 저장");
+        accountRepository.save(newAccount);
+
+        log.info("영화 엔티티 호출 / 생성");
+        List<Movie> movies = findOrCreateFavoriteMovies(requestDto.getFavoriteMovies());
+
+        log.info("관심 영화 계정과 연결");
+        List<FavoriteMovie> favoriteMovies = movies.stream()
+                .map(movie -> FavoriteMovie.builder()
+                        .movie(movie)
+                        .account(newAccount)
+                        .build())
+                .toList();
+        log.info("영화 {}", favoriteMovies.size());
+        favoriteMovieRepository.saveAll(favoriteMovies);
+        return newAccount;
+    }
+
+    @Test
+    void deleteExpiredAccount() {
+
+        Account account = getAccount();
+        DeleteAccountRequestDto deleteAccountRequestDto = new DeleteAccountRequestDto("pass");
+
+        accountService.deleteAccount(deleteAccountRequestDto, AccountDto.from(account));
+        account.updateStatusToDeleted(LocalDateTime.of(2023, 4, 3, 0, 0, 0));
+        accountRepository.save(account);
+        Optional<List<Account>> deletedAccounts = accountRepository.findDeletedAccounts();
+        Assertions.assertEquals(deletedAccounts.isPresent(), true);
+        Assertions.assertEquals(deletedAccounts.get().size(), 1);
+        String email = account.getEmail();
+
+        if (deletedAccounts.isPresent()) {
+            List<Account> deletedList = deletedAccounts.get();
+            deletedList.stream().filter(account1 -> {
+                long daysBetween = ChronoUnit.DAYS.between(account1.getDeleteRegisteredDate(), LocalDateTime.now());
+                return daysBetween >= 7;
+            }).forEach(account1 -> accountService.deleteExpiredAccount(account1));
+        }
+
+        Optional<Account> optionalAccount = accountRepository.findByEmail(email);
+        Assertions.assertEquals(true, optionalAccount.isEmpty());
+
+    }
+}

--- a/src/test/java/com/filmdoms/community/account/service/TotalAccountServiceTest.java
+++ b/src/test/java/com/filmdoms/community/account/service/TotalAccountServiceTest.java
@@ -1,0 +1,409 @@
+package com.filmdoms.community.account.service;
+
+import com.filmdoms.community.account.data.DefaultProfileImage;
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
+import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.data.entity.FavoriteMovie;
+import com.filmdoms.community.account.data.entity.Movie;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.repository.FavoriteMovieRepository;
+import com.filmdoms.community.account.repository.MovieRepository;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.Tag;
+import com.filmdoms.community.article.data.dto.request.create.ArticleCreateRequestDto;
+import com.filmdoms.community.article.data.dto.request.create.CriticCreateRequestDto;
+import com.filmdoms.community.article.data.dto.request.create.FilmUniverseCreateRequestDto;
+import com.filmdoms.community.article.data.dto.response.boardlist.ParentBoardListResponseDto;
+import com.filmdoms.community.article.data.dto.response.mainpage.ParentMainPageResponseDto;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.article.service.ArticleService;
+import com.filmdoms.community.comment.data.dto.request.CommentCreateRequestDto;
+import com.filmdoms.community.comment.data.dto.response.CommentCreateResponseDto;
+import com.filmdoms.community.comment.data.entity.Comment;
+import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.comment.service.CommentService;
+import com.filmdoms.community.file.data.entity.File;
+import com.filmdoms.community.file.repository.FileRepository;
+import com.filmdoms.community.vote.data.entity.Vote;
+import com.filmdoms.community.vote.repository.VoteRepository;
+import com.filmdoms.community.vote.service.VoteService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Slf4j
+@DisplayName("계정삭제 테스트")
+class TotalAccountServiceTest {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private DefaultProfileImage defaultProfileImage;
+    @Autowired
+    private AccountService accountService;
+    @Autowired
+    private ArticleService articleService;
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private ArticleRepository articleRepository;
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private VoteService voteService;
+
+    @Autowired
+    private MovieRepository movieRepository;
+    @Autowired
+    private FavoriteMovieRepository favoriteMovieRepository;
+    @Autowired
+    private FileRepository fileRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private VoteRepository voteRepository;
+
+    private List<Movie> findOrCreateFavoriteMovies(List<String> movieNames) {
+
+        log.info("기존 영화 엔티티 호출");
+        List<Movie> existingMovies = movieRepository.findAllByNames(movieNames);
+
+        log.info("영화 엔티티 이름 추출");
+        Set<String> existingMovieNames = existingMovies.stream()
+                .map(Movie::getName)
+                .collect(Collectors.toSet());
+
+        log.info("새 영화 엔티티 생성");
+        List<Movie> newMovies = movieNames.stream()
+                .filter(name -> !existingMovieNames.contains(name))
+                .map(Movie::new)
+                .toList();
+
+        log.info("새 영화 엔티티 저장");
+        // JPA는 Id 생성을 AutoIncrement로 지정하면 벌크 insert를 수행할 수 없다. 어쩔 수 없이 쿼리 N개 발생.
+        List<Movie> savedMovies = movieRepository.saveAll(newMovies);
+
+        return Stream.concat(existingMovies.stream(), savedMovies.stream()).toList();
+    }
+
+    private Account getAccount() {
+        // 계정 생성
+        List<String> favMovie = List.of("토르", "스파이더맨", "영화123");
+        JoinRequestDto requestDto = new JoinRequestDto("test@naver.com", "pass", "nickname1223", favMovie, "testetmailuuid");
+
+        log.info("Account 엔티티 생성");
+        Account newAccount = Account.builder()
+                //.username(requestDto.getUsername())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .nickname(requestDto.getNickname())
+                .email(requestDto.getEmail())
+                .role(AccountRole.USER)
+                .profileImage(defaultProfileImage.getDefaultProfileImage())
+                .build();
+
+        log.info("Account 엔티티 저장");
+        accountRepository.save(newAccount);
+
+        log.info("영화 엔티티 호출 / 생성");
+        List<Movie> movies = findOrCreateFavoriteMovies(requestDto.getFavoriteMovies());
+
+        log.info("관심 영화 계정과 연결");
+        List<FavoriteMovie> favoriteMovies = movies.stream()
+                .map(movie -> FavoriteMovie.builder()
+                        .movie(movie)
+                        .account(newAccount)
+                        .build())
+                .toList();
+        log.info("영화 {}", favoriteMovies.size());
+        favoriteMovieRepository.saveAll(favoriteMovies);
+        return newAccount;
+    }
+
+    private void createArticlesAndTryVoting(Account account) {
+        createAllArticle(account);
+        tryVote(account);
+    }
+
+    private void tryVote(Account account) {
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (Category category : categorys) {
+
+            // 세부 게시판 좋아요 테스트
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                for (ParentBoardListResponseDto articles : articleList) {
+                    voteService.toggleVote(AccountDto.from(account), articles.getId());
+                }
+
+            }
+        }
+
+
+    }
+
+    private void createAllArticle(Account account) {
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        List<Tag> movieTagList;
+        for (Category category : categorys) {
+            switch (category) {
+                case MOVIE:
+                    movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                            .filter(tag -> tag.getCategory() == category)
+                            .toList();
+                    for (Tag movieTag : movieTagList) {
+                        createMovie("영화 게시글" + movieTag, category, movieTag, "내용입니다", false, account);
+                    }
+                    break;
+                case FILM_UNIVERSE:
+                    movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                            .filter(tag -> tag.getCategory() == category)
+                            .toList();
+                    for (Tag movieTag : movieTagList) {
+                        File defaultImage = File.builder() //게시글과 매핑될 디폴트 이미지 생성
+                                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                                .originalFileName("original_file_name")
+                                .build();
+                        File savedFile1 = fileRepository.save(defaultImage);
+                        createFilmUniverse("영화 게시글" + movieTag, category, movieTag, "내용입니다", false, LocalDateTime.now(), LocalDateTime.now(), savedFile1.getId(), account);
+                    }
+                    break;
+                case CRITIC:
+                    movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                            .filter(tag -> tag.getCategory() == category)
+                            .toList();
+                    for (Tag movieTag : movieTagList) {
+                        File defaultImage = File.builder() //게시글과 매핑될 디폴트 이미지 생성
+                                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                                .originalFileName("original_file_name")
+                                .build();
+                        File savedFile2 = fileRepository.save(defaultImage);
+                        createCritic("영화 게시글" + movieTag, category, movieTag, "내용입니다", false, savedFile2.getId(), account);
+                    }
+                    break;
+
+
+            }
+        }
+
+
+    }
+
+    private void createMovie(String title, Category category, Tag tag, String content, boolean containsImage, Account account) {
+        ArticleCreateRequestDto movieRequestDto = new ArticleCreateRequestDto(title, category, tag, content, containsImage);
+        articleService.createArticle(movieRequestDto, AccountDto.from(account));
+    }
+
+    private void createFilmUniverse(String title, Category category, Tag tag, String content, boolean containsImage, LocalDateTime startAt, LocalDateTime endAt, Long mainImageId, Account account) {
+        FilmUniverseCreateRequestDto filmUniverseCreateRequestDto
+                = new FilmUniverseCreateRequestDto(title, category, tag, content, containsImage, startAt, endAt, mainImageId);
+        articleService.createArticle(filmUniverseCreateRequestDto, AccountDto.from(account));
+    }
+
+    private void createCritic(String title, Category category, Tag tag, String content, boolean containsImage, Long mainImageId, Account account) {
+        CriticCreateRequestDto criticCreateRequestDto = new CriticCreateRequestDto(title, category, tag, content, containsImage, mainImageId);
+        articleService.createArticle(criticCreateRequestDto, AccountDto.from(account));
+
+    }
+
+    private void createComment(Account account) {
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (Category category : categorys) {
+
+            // 세부 게시판 좋아요 테스트
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                for (ParentBoardListResponseDto article : articleList) {
+                    CommentCreateResponseDto commentCreateResponseDto = createParentComment(article.getId(), "부모댓글", false, account);
+                    createChildComment(article.getId(), commentCreateResponseDto.getCommentId(), "자식댓글", false, account);
+
+                }
+
+            }
+        }
+
+    }
+
+    private CommentCreateResponseDto createParentComment(Long articleId, String content, boolean isManagerComment, Account account) {
+        CommentCreateRequestDto dto = new CommentCreateRequestDto(articleId, null, content, false);
+        CommentCreateResponseDto comment = commentService.createComment(dto, AccountDto.from(account));
+        return comment;
+    }
+
+    private void createChildComment(Long articleId, Long parentCommentId, String content, boolean isManagerComment, Account account) {
+        CommentCreateRequestDto dto2 = new CommentCreateRequestDto(articleId, parentCommentId, content, false);
+        commentService.createComment(dto2, AccountDto.from(account));
+    }
+
+    @Test
+    @DisplayName("회원 가입 테스트")
+    public void testAccount() {
+        Account newAccount = getAccount();
+        Assertions.assertEquals(newAccount.getEmail(), "test@naver.com");
+        Assertions.assertEquals(newAccount.getNickname(), "nickname1223");
+        Assertions.assertEquals(newAccount.getProfileImage(), defaultProfileImage.getDefaultProfileImage());
+
+    }
+
+    @Test
+    @DisplayName("게시글 작성 테스트")
+    public void articleGenerateTest() {
+        // 5개의 게시글을 생성
+        // 총 4개의 게시글에 좋아요 처리
+        // 총 4개의 게시글에 1개씩 부모댓글 자식댓글 생성후
+        // 계정 삭제 테스트
+
+        Account newAccount = getAccount();
+        createAllArticle(newAccount);
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (Category category : categorys) {
+            // 메인페이지 테스트
+            List<? extends ParentMainPageResponseDto> mainPageDtoList = articleService.getMainPageDtoList(category, 10);
+            // 태그 갯수만큼 게시글 생성되었는지 체크
+            Assertions.assertEquals(mainPageDtoList.size(),
+                    Arrays.stream(Tag.values()).filter(tag -> tag.getCategory() == category).toList().size());
+
+
+            // 세부 게시판 테스트
+            Page<? extends ParentBoardListResponseDto> boardList = articleService.getBoardList(category, null, pageable);
+            // 태그그 없이 카테고리만 응답시에는 태그 갯수만큼 게시글 존재여부 확인
+            assertEquals(boardList.getTotalElements(), Arrays.stream(Tag.values()).filter(tag -> tag.getCategory() == category).toList().size());
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                assertEquals(articleList.getTotalElements(), 1);
+            }
+        }
+
+    }
+
+    @Test
+    @DisplayName("Deleted 처리 후 게시글이 보이는지 테스트")
+    public void articleDeleteTest() {
+        Account newAccount = getAccount();
+        createArticlesAndTryVoting(newAccount);
+
+        DeleteAccountRequestDto deleteAccountRequestDto = new DeleteAccountRequestDto("pass");
+
+        accountService.deleteAccount(deleteAccountRequestDto, AccountDto.from(newAccount));
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (Category category : categorys) {
+            // 메인페이지 테스트
+            List<? extends ParentMainPageResponseDto> mainPageDtoList = articleService.getMainPageDtoList(category, 10);
+            // 0개 반환 확인
+            Assertions.assertEquals(mainPageDtoList.size(), 0);
+
+
+            // 세부 게시판 테스트
+            Page<? extends ParentBoardListResponseDto> boardList = articleService.getBoardList(category, null, pageable);
+            // 태그그 없이 카테고리만 응답시에는 태그 갯수만큼 게시글 존재여부 확인
+            assertEquals(boardList.getTotalElements(), 0);
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                assertEquals(articleList.getTotalElements(), 0);
+            }
+        }
+
+
+    }
+
+    @Test
+    @DisplayName("좋아요 테스트")
+    public void voteTest() {
+        Account newAccount = getAccount();
+        createArticlesAndTryVoting(newAccount);
+
+        List<Vote> votes = voteRepository.findAll().stream().toList();
+        // 좋아요가 전부 눌렸는지 체크
+        Assertions.assertEquals(votes.size(), Tag.values().length);
+
+
+    }
+
+    @Test
+    @DisplayName("댓글 작성 테스트")
+    public void commentTest() {
+        Account account = getAccount();
+        createArticlesAndTryVoting(account);
+        createComment(account);
+        int commentSize = 2 * (Tag.values().length); // 부모 & 자식댓글
+        List<Comment> commentList = commentRepository.findByAuthor(account);
+        Assertions.assertEquals(commentList.size(), commentSize);
+
+    }
+
+    @Test
+    @DisplayName("실제 회원 탈퇴 테스트")
+    public void deleteExpiredAccount() {
+        Account account = getAccount();
+        createArticlesAndTryVoting(account);
+        createComment(account);
+        String email = account.getEmail();
+        Long id = account.getId();
+
+        accountService.deleteExpiredAccount(account);
+        Optional<Article> articleOptional = articleRepository.findById(id);
+        // 모든 게시글 삭제 확인
+        Assertions.assertEquals(articleOptional.isEmpty(), true);
+        Optional<Account> emailAccount = accountRepository.findByEmail(email);
+        // 모든 댓글 삭제 확인
+        Optional<Comment> commentOptional = commentRepository.findById(id);
+        Assertions.assertEquals(commentOptional.isEmpty(), true);
+        // 회원 삭제 확인
+        Assertions.assertEquals(emailAccount.isEmpty(), true);
+
+    }
+
+
+}


### PR DESCRIPTION
회원 탈퇴 기능을 추가했습니다. 아래는 주요 변경 사항입니다
1. 스프링 스케줄러를 사용해 매일 오전 3시에 Deleted 된 사용자가 있는지 확인합니다. 사용자가 있다면 7일이 지났는 지 확인 후 지났다면 삭제합니다.
2. fileContent 종속성을 삭제하였고, 실제 엔티티와 Dto 에 있던 file과 관련된 코드들을 삭제하였습니다.
3. 각 엔티티(Account, Article, Comment) 에 Active - Deleted 로 변경할 수 있는 메서드가 없다면 추가 하였습니다. 이 과정에서
Account 엔티티의 경우에 삭제 요청을 한 날짜를 기록하는 LocalDatetime을 엔티티에 추가하였습니다.
4. 각 Repository 에서 게시글을 가져오는 쿼리들에 Active 한 게시글만 가져오게 쿼리 수정하였습니다.

추가로 구현되어야 되는 부분은
사용자가 삭제 된 계정인데 로그인 시도를 할 경우 deleted 상태에서 ACTIVE 로 변경 후 게시글, 댓글을 모두 Active로 변경합니다.
댓글 삭제의 경우, 자신이 작성한 게시글에 달지 않은 댓글의 경우, 부모 댓글인 경우 삭제 시에 문제가 발생합니다. 해당 부분 처리하는 방법 구현이 필요합니다.
