### PR TITLE
Deleted 된 댓글에 대한 요청 처리 기타 메서드 , 쿼리 변경

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/entity/Account.java
+++ b/src/main/java/com/filmdoms/community/account/data/entity/Account.java
@@ -88,4 +88,10 @@ public class Account extends BaseTimeEntity {
         this.accountStatus = AccountStatus.DELETED;
         this.deleteRegisteredDate = localDateTime;
     }
+
+    public void updateStatusToActive(){
+        this.accountStatus = AccountStatus.ACTIVE;
+        this.deleteRegisteredDate = null;
+
+    }
 }

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -22,9 +22,11 @@ import com.filmdoms.community.account.repository.MovieRepository;
 import com.filmdoms.community.account.repository.RefreshTokenRepository;
 import com.filmdoms.community.account.service.utils.RedisUtil;
 import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.PostStatus;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.article.repository.ArticleRepository;
 import com.filmdoms.community.article.service.ArticleService;
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
 import com.filmdoms.community.comment.data.entity.Comment;
 import com.filmdoms.community.comment.repository.CommentRepository;
 import com.filmdoms.community.config.jwt.JwtTokenProvider;
@@ -64,6 +66,7 @@ public class AccountService {
     private final RedisUtil redisUtil;
     private final DefaultProfileImage defaultProfileImage;
     private final ArticleService articleService;
+    private final AccountStatusCheck accountStatusCheck;
 
     @Transactional
     public LoginDto login(String email, String password) {
@@ -77,7 +80,7 @@ public class AccountService {
             throw new ApplicationException(ErrorCode.INVALID_PASSWORD);
         }
 
-        checkAccountStatus(account);
+        accountStatusCheck.checkAccountStatus(account);
 
         log.info("저장된 토큰 존재 여부 확인, 없다면 생성");
         String key = account.getId().toString();
@@ -434,10 +437,5 @@ public class AccountService {
         favoriteMovieRepository.saveAll(favoriteMovies);
     }
 
-    public static void checkAccountStatus(Account account) {
-        switch (account.getAccountStatus()) {
-            case INACTIVE -> throw new ApplicationException(ErrorCode.INACTIVE_ACCOUNT);
-            case DELETED -> throw new ApplicationException(ErrorCode.DELETED_ACCOUNT);
-        }
-    }
+
 }

--- a/src/main/java/com/filmdoms/community/account/service/AccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountService.java
@@ -345,17 +345,10 @@ public class AccountService {
         }
 
         log.info("기존 게시글,댓글 deleted처리");
-        List<Article> articles = articleRepository.findByAuthor(account);
-        for (Article article : articles) {
-            article.changePostStatusToDeleted();
-        }
-        List<Comment> commentList = commentRepository.findByAuthor(account);
-        for (Comment comment : commentList) {
-            comment.changeStatusToDeleted();
-        }
-
+        articleRepository.updateArticlesPostStatus(account, PostStatus.DELETED);
+        commentRepository.updateCommentPostStatus(account, CommentStatus.DELETED);
         account.updateStatusToDeleted(LocalDateTime.now());
-
+        accountRepository.save(account);
     }
 
     @Transactional

--- a/src/main/java/com/filmdoms/community/account/service/AccountStatusCheck.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountStatusCheck.java
@@ -1,0 +1,41 @@
+package com.filmdoms.community.account.service;
+
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.article.data.constant.PostStatus;
+import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
+import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.exception.ApplicationException;
+import com.filmdoms.community.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AccountStatusCheck {
+
+    private final ArticleRepository articleRepository;
+    private final CommentRepository commentRepository;
+    private final AccountRepository accountRepository;
+
+
+    public void checkAccountStatus(Account account) {
+        switch (account.getAccountStatus()) {
+            case INACTIVE:
+                throw new ApplicationException(ErrorCode.INACTIVE_ACCOUNT);
+            case DELETED:
+                articleRepository.updateArticlesPostStatus(account, PostStatus.DELETED);
+                commentRepository.updateCommentPostStatus(account, CommentStatus.DELETED);
+                account.updateStatusToActive();
+                accountRepository.save(account);
+                break;
+        }
+    }
+
+}

--- a/src/main/java/com/filmdoms/community/account/service/AccountStatusCheck.java
+++ b/src/main/java/com/filmdoms/community/account/service/AccountStatusCheck.java
@@ -30,8 +30,8 @@ public class AccountStatusCheck {
             case INACTIVE:
                 throw new ApplicationException(ErrorCode.INACTIVE_ACCOUNT);
             case DELETED:
-                articleRepository.updateArticlesPostStatus(account, PostStatus.DELETED);
-                commentRepository.updateCommentPostStatus(account, CommentStatus.DELETED);
+                articleRepository.updateArticlesPostStatus(account, PostStatus.ACTIVE);
+                commentRepository.updateCommentPostStatus(account, CommentStatus.ACTIVE);
                 account.updateStatusToActive();
                 accountRepository.save(account);
                 break;

--- a/src/main/java/com/filmdoms/community/account/service/TokenAuthenticationService.java
+++ b/src/main/java/com/filmdoms/community/account/service/TokenAuthenticationService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 public class TokenAuthenticationService {
 
     private final AccountRepository accountRepository;
+    private final AccountStatusCheck accountStatusCheck;
+
 
     /**
      * 유저 ID로 계정 정보를 찾는다.
@@ -31,7 +33,7 @@ public class TokenAuthenticationService {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
-        AccountService.checkAccountStatus(account);
+        accountStatusCheck.checkAccountStatus(account);
 
         return AccountDto.from(account);
     }

--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -78,11 +78,7 @@ public class Article extends BaseTimeEntity {
         this.status = PostStatus.DELETED;
     }
 
-    public void changePostStatusToActive() {
-        this.status = PostStatus.ACTIVE;
+    public void changePostStatusToActive() { this.status = PostStatus.ACTIVE;}
       
-    public int addView() {
-        return ++view;
-
-    }
+    public int addView() { return ++view; }
 }

--- a/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
+++ b/src/main/java/com/filmdoms/community/article/repository/ArticleRepository.java
@@ -2,11 +2,13 @@ package com.filmdoms.community.article.repository;
 
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.PostStatus;
 import com.filmdoms.community.article.data.constant.Tag;
 import com.filmdoms.community.article.data.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,7 +17,7 @@ import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("Select a from Article a where a.category =:category and a.status ='ACTIVE'")
-    List<Article> findByCategory(@Param("category")Category category, Pageable pageable);
+    List<Article> findByCategory(@Param("category") Category category, Pageable pageable);
 
     //JPA 기본 제공 findAll 메서드는 페이지 객체를 반환하므로 필요 없는 count 쿼리가 나감 -> 리스트를 반환하는 메서드를 따로 만듦
     @Query("SELECT a FROM Article a where a.status = 'ACTIVE'")
@@ -65,4 +67,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Page<Article> findByAuthor(Account author, Pageable pageable);
 
     List<Article> findByAuthor(Account account);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Article a SET a.status =:postStatus WHERE a.author =:author")
+    void updateArticlesPostStatus(@Param("author") Account author, @Param("postStatus") PostStatus postStatus);
+
 }

--- a/src/main/java/com/filmdoms/community/comment/data/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/filmdoms/community/comment/data/dto/response/CommentResponseDto.java
@@ -3,9 +3,10 @@ package com.filmdoms.community.comment.data.dto.response;
 import com.filmdoms.community.account.data.dto.response.DetailPageAccountResponseDto;
 import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
 import com.filmdoms.community.comment.data.entity.Comment;
+import lombok.Getter;
+
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import lombok.Getter;
 
 /**
  * 게시글 상세 페이지에서 댓글 정보를 주기 위한 응답 DTO, 자식 댓글 용도
@@ -24,13 +25,23 @@ public class CommentResponseDto {
 
     protected CommentResponseDto(Comment comment) {
         this.id = comment.getId();
-        this.content = comment.getContent();
-        this.status = comment.getStatus();
-        this.likes = comment.getVoteCount();
         this.createdAt = ZonedDateTime.of(comment.getDateCreated(), ZoneId.systemDefault()).toInstant().toEpochMilli();
         this.updatedAt = ZonedDateTime.of(comment.getDateLastModified(), ZoneId.systemDefault()).toInstant().toEpochMilli();
         this.isManagerComment = comment.isManagerComment();
-        this.author = DetailPageAccountResponseDto.from(comment.getAuthor());
+
+        if (comment.getStatus() == CommentStatus.ACTIVE) {
+            this.content = comment.getContent();
+            this.status = comment.getStatus();
+            this.likes = comment.getVoteCount();
+            this.author = DetailPageAccountResponseDto.from(comment.getAuthor());
+        } else {
+            this.content = "삭제된 댓글입니다.";
+            this.status = comment.getStatus();
+            this.likes = 0;
+            this.author = null;
+        }
+
+
     }
 
     public static CommentResponseDto from(Comment comment) {

--- a/src/main/java/com/filmdoms/community/comment/data/dto/response/ParentCommentResponseDto.java
+++ b/src/main/java/com/filmdoms/community/comment/data/dto/response/ParentCommentResponseDto.java
@@ -1,5 +1,6 @@
 package com.filmdoms.community.comment.data.dto.response;
 
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
 import com.filmdoms.community.comment.data.entity.Comment;
 import lombok.Getter;
 
@@ -33,7 +34,7 @@ public class ParentCommentResponseDto extends CommentResponseDto {
                 .collect(partitioningBy(comment -> comment.getParentComment() == null, toList())); //부모 댓글 여부로 분류
         //isParentComment={true=부모댓글 리스트(생성순 정렬), false=자식댓글 리스트(생성순 정렬)}
 
-        Map<Comment, List<CommentResponseDto>> parentToChildren = isParentComment.get(false).stream()
+        Map<Comment, List<CommentResponseDto>> parentToChildren = isParentComment.get(false).stream().filter(comment -> comment.getStatus() == CommentStatus.ACTIVE)
                 .collect(groupingBy(Comment::getParentComment, mapping(CommentResponseDto::from, toList()))); //자식 댓글을 부모 댓글을 키로 그룹화하고, DTO로 변환
         //parentToChildren={ 부모댓글1=부모댓글1의 자식댓글 DTO 리스트, 부모댓글2=부모댓글2의 자식댓글 DTO 리스트, ...} (자식댓글이 없는 부모댓글은 값으로 null을 가짐)
 

--- a/src/main/java/com/filmdoms/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/filmdoms/community/comment/repository/CommentRepository.java
@@ -2,10 +2,12 @@ package com.filmdoms.community.comment.repository;
 
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
 import com.filmdoms.community.comment.data.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,5 +30,11 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByAuthorWithArticle(@Param("author") Account author, Pageable pageable);
 
     List<Comment> findByArticle(Article article);
+
     List<Comment> findByAuthor(Account account);
+
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Comment c SET c.status =:commentStatus WHERE c.author =:author")
+    void updateCommentPostStatus(@Param("author") Account author, @Param("commentStatus") CommentStatus commentStatus);
 }

--- a/src/main/java/com/filmdoms/community/config/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/filmdoms/community/config/oauth/CustomOAuthSuccessHandler.java
@@ -10,6 +10,8 @@ import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.repository.RefreshTokenRepository;
 import com.filmdoms.community.account.service.AccountService;
+import com.filmdoms.community.account.service.AccountStatusCheck;
+import com.filmdoms.community.article.repository.ArticleRepository;
 import com.filmdoms.community.config.jwt.JwtTokenProvider;
 import com.filmdoms.community.exception.ApplicationException;
 import com.filmdoms.community.exception.ErrorCode;
@@ -40,6 +42,9 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
     private final DefaultProfileImage defaultProfileImage;
+    private final ArticleRepository articleRepository;
+    private final AccountService accountService;
+    private final AccountStatusCheck accountStatusCheck;
 
     protected void handle(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
@@ -55,7 +60,7 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             Account account = accountRepository.findByEmail(email)
                     .orElseGet(() -> createGuestAccountWithEmail(email)); //가입된 이메일이 아닌 경우 GUEST 등급의 Account 생성
             checkSocialLoginAccount(account); //소셜 로그인 계정 여부 확인
-            AccountService.checkAccountStatus(account);
+            accountStatusCheck.checkAccountStatus(account);
 
             String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(account.getId()));
             ResponseCookie refreshTokenCookie = resolveRefreshTokenCookieFromAccount(account);

--- a/src/test/java/com/filmdoms/community/comment/data/dto/response/ParentCommentResponseDtoTest.java
+++ b/src/test/java/com/filmdoms/community/comment/data/dto/response/ParentCommentResponseDtoTest.java
@@ -1,0 +1,394 @@
+package com.filmdoms.community.comment.data.dto.response;
+
+import com.filmdoms.community.account.data.DefaultProfileImage;
+import com.filmdoms.community.account.data.constant.AccountRole;
+import com.filmdoms.community.account.data.dto.AccountDto;
+import com.filmdoms.community.account.data.dto.request.DeleteAccountRequestDto;
+import com.filmdoms.community.account.data.dto.request.JoinRequestDto;
+import com.filmdoms.community.account.data.entity.Account;
+import com.filmdoms.community.account.data.entity.FavoriteMovie;
+import com.filmdoms.community.account.data.entity.Movie;
+import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.account.repository.FavoriteMovieRepository;
+import com.filmdoms.community.account.repository.MovieRepository;
+import com.filmdoms.community.account.service.AccountService;
+import com.filmdoms.community.article.data.constant.Category;
+import com.filmdoms.community.article.data.constant.Tag;
+import com.filmdoms.community.article.data.dto.request.create.ArticleCreateRequestDto;
+import com.filmdoms.community.article.data.dto.request.create.CriticCreateRequestDto;
+import com.filmdoms.community.article.data.dto.request.create.FilmUniverseCreateRequestDto;
+import com.filmdoms.community.article.data.dto.response.boardlist.ParentBoardListResponseDto;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.article.service.ArticleService;
+import com.filmdoms.community.comment.data.dto.request.CommentCreateRequestDto;
+import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.comment.service.CommentService;
+import com.filmdoms.community.file.data.entity.File;
+import com.filmdoms.community.file.repository.FileRepository;
+import com.filmdoms.community.vote.repository.VoteRepository;
+import com.filmdoms.community.vote.service.VoteService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Slf4j
+@DisplayName("계정삭제 테스트")
+class ParentCommentResponseDtoTest {
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private DefaultProfileImage defaultProfileImage;
+    @Autowired
+    private AccountService accountService;
+    @Autowired
+    private ArticleService articleService;
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private ArticleRepository articleRepository;
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private VoteService voteService;
+
+    @Autowired
+    private MovieRepository movieRepository;
+    @Autowired
+    private FavoriteMovieRepository favoriteMovieRepository;
+    @Autowired
+    private FileRepository fileRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private VoteRepository voteRepository;
+
+    private List<Movie> findOrCreateFavoriteMovies(List<String> movieNames) {
+
+        log.info("기존 영화 엔티티 호출");
+        List<Movie> existingMovies = movieRepository.findAllByNames(movieNames);
+
+        log.info("영화 엔티티 이름 추출");
+        Set<String> existingMovieNames = existingMovies.stream()
+                .map(Movie::getName)
+                .collect(Collectors.toSet());
+
+        log.info("새 영화 엔티티 생성");
+        List<Movie> newMovies = movieNames.stream()
+                .filter(name -> !existingMovieNames.contains(name))
+                .map(Movie::new)
+                .toList();
+
+        log.info("새 영화 엔티티 저장");
+        // JPA는 Id 생성을 AutoIncrement로 지정하면 벌크 insert를 수행할 수 없다. 어쩔 수 없이 쿼리 N개 발생.
+        List<Movie> savedMovies = movieRepository.saveAll(newMovies);
+
+        return Stream.concat(existingMovies.stream(), savedMovies.stream()).toList();
+    }
+
+    private Account getAccount() {
+        // 계정 생성
+        List<String> favMovie = List.of("토르", "스파이더맨", "영화123");
+        JoinRequestDto requestDto = new JoinRequestDto("test@naver.com", "pass", "nickname1223", favMovie, "testetmailuuid");
+
+        log.info("Account 엔티티 생성");
+        Account newAccount = Account.builder()
+                //.username(requestDto.getUsername())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .nickname(requestDto.getNickname())
+                .email(requestDto.getEmail())
+                .role(AccountRole.USER)
+                .profileImage(defaultProfileImage.getDefaultProfileImage())
+                .build();
+
+        log.info("Account 엔티티 저장");
+        accountRepository.save(newAccount);
+
+        log.info("영화 엔티티 호출 / 생성");
+        List<Movie> movies = findOrCreateFavoriteMovies(requestDto.getFavoriteMovies());
+
+        log.info("관심 영화 계정과 연결");
+        List<FavoriteMovie> favoriteMovies = movies.stream()
+                .map(movie -> FavoriteMovie.builder()
+                        .movie(movie)
+                        .account(newAccount)
+                        .build())
+                .toList();
+        log.info("영화 {}", favoriteMovies.size());
+        favoriteMovieRepository.saveAll(favoriteMovies);
+        return newAccount;
+    }
+
+    private void createAllArticle(Account account) {
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        List<Tag> movieTagList;
+        for (Category category : categorys) {
+            switch (category) {
+                case MOVIE:
+                    movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                            .filter(tag -> tag.getCategory() == category)
+                            .toList();
+                    for (Tag movieTag : movieTagList) {
+                        createMovie("영화 게시글" + movieTag, category, movieTag, "내용입니다", false, account);
+                    }
+                    break;
+                case FILM_UNIVERSE:
+                    movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                            .filter(tag -> tag.getCategory() == category)
+                            .toList();
+                    for (Tag movieTag : movieTagList) {
+                        File defaultImage = File.builder() //게시글과 매핑될 디폴트 이미지 생성
+                                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                                .originalFileName("original_file_name")
+                                .build();
+                        File savedFile1 = fileRepository.save(defaultImage);
+                        createFilmUniverse("영화 게시글" + movieTag, category, movieTag, "내용입니다", false, LocalDateTime.now(), LocalDateTime.now(), savedFile1.getId(), account);
+                    }
+                    break;
+                case CRITIC:
+                    movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                            .filter(tag -> tag.getCategory() == category)
+                            .toList();
+                    for (Tag movieTag : movieTagList) {
+                        File defaultImage = File.builder() //게시글과 매핑될 디폴트 이미지 생성
+                                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
+                                .originalFileName("original_file_name")
+                                .build();
+                        File savedFile2 = fileRepository.save(defaultImage);
+                        createCritic("영화 게시글" + movieTag, category, movieTag, "내용입니다", false, savedFile2.getId(), account);
+                    }
+                    break;
+
+
+            }
+        }
+
+
+    }
+
+    private void createMovie(String title, Category category, Tag tag, String content, boolean containsImage, Account account) {
+        ArticleCreateRequestDto movieRequestDto = new ArticleCreateRequestDto(title, category, tag, content, containsImage);
+        articleService.createArticle(movieRequestDto, AccountDto.from(account));
+    }
+
+    private void createFilmUniverse(String title, Category category, Tag tag, String content, boolean containsImage, LocalDateTime startAt, LocalDateTime endAt, Long mainImageId, Account account) {
+        FilmUniverseCreateRequestDto filmUniverseCreateRequestDto
+                = new FilmUniverseCreateRequestDto(title, category, tag, content, containsImage, startAt, endAt, mainImageId);
+        articleService.createArticle(filmUniverseCreateRequestDto, AccountDto.from(account));
+    }
+
+    private void createCritic(String title, Category category, Tag tag, String content, boolean containsImage, Long mainImageId, Account account) {
+        CriticCreateRequestDto criticCreateRequestDto = new CriticCreateRequestDto(title, category, tag, content, containsImage, mainImageId);
+        articleService.createArticle(criticCreateRequestDto, AccountDto.from(account));
+
+    }
+
+    private void createCommentCase1(Account account, Account account2) {
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (Category category : categorys) {
+
+            // 세부 게시판 좋아요 테스트
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                for (ParentBoardListResponseDto article : articleList) {
+                    CommentCreateResponseDto commentCreateResponseDto = createParentComment(article.getId(), "2번째 계정이 만든 부모 댓글", false, account2);
+                    createChildComment(article.getId(), commentCreateResponseDto.getCommentId(), "2번째 계정이 만든 댓글", false, account2);
+                    createChildComment(article.getId(), commentCreateResponseDto.getCommentId(), "자식댓글", false, account);
+
+                }
+
+            }
+        }
+
+    }
+
+    private void createCommentCase2(Account account, Account account2) {
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (Category category : categorys) {
+
+            // 세부 게시판 좋아요 테스트
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                for (ParentBoardListResponseDto article : articleList) {
+                    CommentCreateResponseDto commentCreateResponseDto = createParentComment(article.getId(), "부모 댓글", false, account2);
+                    createChildComment(article.getId(), commentCreateResponseDto.getCommentId(), "2번째 계정이 만든 댓글", false, account2);
+                    createChildComment(article.getId(), commentCreateResponseDto.getCommentId(), "자식댓글", false, account);
+                    createChildComment(article.getId(), commentCreateResponseDto.getCommentId(), "2번째 계정이 만든 댓글22", false, account2);
+
+                }
+
+            }
+        }
+
+    }
+
+    private CommentCreateResponseDto createParentComment(Long articleId, String content, boolean isManagerComment, Account account) {
+        CommentCreateRequestDto dto = new CommentCreateRequestDto(articleId, null, content, false);
+        CommentCreateResponseDto comment = commentService.createComment(dto, AccountDto.from(account));
+        return comment;
+    }
+
+    private void createChildComment(Long articleId, Long parentCommentId, String content, boolean isManagerComment, Account account) {
+        CommentCreateRequestDto dto2 = new CommentCreateRequestDto(articleId, parentCommentId, content, false);
+        commentService.createComment(dto2, AccountDto.from(account));
+    }
+
+    private Account getAccount2() {
+        // 계정 생성
+        List<String> favMovie = List.of("토르", "스파이더맨", "영화123");
+        JoinRequestDto requestDto = new JoinRequestDto("test2@naver.com", "pass", "nicknam23", favMovie, "tesmailuuid");
+
+        log.info("Account 엔티티 생성");
+        Account newAccount = Account.builder()
+                //.username(requestDto.getUsername())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .nickname(requestDto.getNickname())
+                .email(requestDto.getEmail())
+                .role(AccountRole.USER)
+                .profileImage(defaultProfileImage.getDefaultProfileImage())
+                .build();
+
+        log.info("Account 엔티티 저장");
+        accountRepository.save(newAccount);
+
+        log.info("영화 엔티티 호출 / 생성");
+        List<Movie> movies = findOrCreateFavoriteMovies(requestDto.getFavoriteMovies());
+
+        log.info("관심 영화 계정과 연결");
+        List<FavoriteMovie> favoriteMovies = movies.stream()
+                .map(movie -> FavoriteMovie.builder()
+                        .movie(movie)
+                        .account(newAccount)
+                        .build())
+                .toList();
+        log.info("영화 {}", favoriteMovies.size());
+        favoriteMovieRepository.saveAll(favoriteMovies);
+        return newAccount;
+    }
+
+    @Test
+    @DisplayName("부모 댓글의 경우 삭제된 댓글입니다. 로  처리되는지 테스트")
+    public void commentTest() {
+        Account account = getAccount();
+        Account account2 = getAccount2();
+        // account 계정으로 모든 게시판에 글을 작성함
+        createAllArticle(account);
+        // 부모 댓글을  account2 로 하여 댓글 작성
+        createCommentCase1(account, account2);
+
+        //account2를 deleted로 처리함
+        DeleteAccountRequestDto deleteAccountRequestDto = new DeleteAccountRequestDto("pass");
+        accountService.deleteAccount(deleteAccountRequestDto, AccountDto.from(account2));
+
+        // 게시글 조회를 위한 코드 모든 카테고리를 한번 씩 조회함
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+        for (Category category : categorys) {
+
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                for (ParentBoardListResponseDto article : articleList) {
+
+                    // 게시글 조회 후 댓글 확인 과정
+                    DetailPageCommentResponseDto detailPageCommentList = commentService.getDetailPageCommentList(article.getId());
+                    List<ParentCommentResponseDto> comments = detailPageCommentList.getComments();
+                    for (ParentCommentResponseDto comment : comments) {
+                        assertEquals("부모 댓글", comment.getContent());
+
+                        List<CommentResponseDto> childComments = comment.getChildComments();
+                        for (CommentResponseDto childComment : childComments) {
+                            // 삭제된 자식 댓글은 보이지 않아서 총 1개가 보임
+                            assertEquals(childComments.size(), 1);
+
+                        }
+                    }
+
+                }
+
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Deleted 처리된 댓글의 경우 응답으로 나가지 않는 경우 테스트")
+    public void commentTest2() {
+        Account account = getAccount();
+        Account account2 = getAccount2();
+        // account 계정으로 모든 게시판에 글을 작성함
+        createAllArticle(account);
+        // 자식 댓글을 account2 로 하여 댓글 작성
+        createCommentCase2(account, account2);
+        log.info("생성 완료");
+        DeleteAccountRequestDto deleteAccountRequestDto = new DeleteAccountRequestDto("pass");
+        accountService.deleteAccount(deleteAccountRequestDto, AccountDto.from(account2));
+
+        List<Category> categorys = Arrays.stream(Category.values()).toList();
+        Pageable pageable = PageRequest.of(0, 20);
+        for (Category category : categorys) {
+
+            // 세부 게시판 좋아요 테스트
+            List<Tag> movieTagList = Arrays.stream(Tag.values()) //영화 게시판 태그만 추출
+                    .filter(tag -> tag.getCategory() == category)
+                    .toList();
+            for (Tag movieTag : movieTagList) {
+                // 태그 있는 경우의 응답
+                Page<? extends ParentBoardListResponseDto> articleList = articleService.getBoardList(category, movieTag, pageable);
+                for (ParentBoardListResponseDto article : articleList) {
+                    DetailPageCommentResponseDto detailPageCommentList = commentService.getDetailPageCommentList(article.getId());
+                    List<ParentCommentResponseDto> comments = detailPageCommentList.getComments();
+                    for (ParentCommentResponseDto comment : comments) {
+                        assertEquals("삭제된 댓글입니다.", comment.getContent());
+                        log.info(comment.getContent());
+                        List<CommentResponseDto> childComments = comment.getChildComments();
+                        for (CommentResponseDto childComment : childComments) {
+                            // 삭제된 자식 댓글은 보이지 않아서 총 1개가 보임
+                            assertEquals(childComments.size(), 1);
+
+                        }
+                    }
+
+                }
+
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
변경된 점은 총 3가지 입니다.

1. Deleted 된 댓글을 보이지 않게 하였습니다.
부모 댓글의 경우 삭제된 댓글입니다. 로 반환 되고 자식 댓글은 보여지지 않습니다
2. Static 메서드 변경
Deleted 될 때 Active로 계정, 게시글 댓글이 변경되어야 되기 때문에 그렇게 코드 수정하였습니다.
3. 상태 변경 시 Modifying 사용
기존 코드는 엔티티를 하나씩 조회해서 Save하기 때문에,  이 부분 해결하기 위해 벌크 연산을 찾아보았고
Data jpa의 경우에 Modifying 을 사용하는 것을 확인하고 적용하였습니다.