### PR TITLE
댓글 삭제 관련 오류코드 생성, 임시 비밀번호 PasswordEncoder 사용

### DIFF
--- a/src/main/java/com/filmdoms/community/account/data/DefaultProfileImage.java
+++ b/src/main/java/com/filmdoms/community/account/data/DefaultProfileImage.java
@@ -19,8 +19,8 @@ public class DefaultProfileImage {
     public void init() {
 
         File file = File.builder()
-                .uuidFileName("7f5fb6d2-40fa-4e3d-81e6-a013af6f4f23.png")
-                .originalFileName("original_file_name")
+                .uuidFileName("8ffbe57a-741e-46a2-bbda-f507ed6c51fb.png")
+                .originalFileName("profile")
                 .build();
         defaultProfileImage = fileRepository.save(file);
 

--- a/src/main/java/com/filmdoms/community/account/service/EmailService.java
+++ b/src/main/java/com/filmdoms/community/account/service/EmailService.java
@@ -3,13 +3,14 @@ package com.filmdoms.community.account.service;
 import com.filmdoms.community.account.data.dto.request.AuthCodeVerificationRequestDto;
 import com.filmdoms.community.account.data.dto.response.EmailAuthDto;
 import com.filmdoms.community.account.data.entity.Account;
-import com.filmdoms.community.exception.ApplicationException;
-import com.filmdoms.community.exception.ErrorCode;
 import com.filmdoms.community.account.repository.AccountRepository;
 import com.filmdoms.community.account.service.utils.PasswordUtil;
 import com.filmdoms.community.account.service.utils.RedisUtil;
+import com.filmdoms.community.exception.ApplicationException;
+import com.filmdoms.community.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,7 @@ public class EmailService {
     private final AccountRepository accountRepository;
     private final AsyncEmailSendService asyncEmailSendService;
     private final RedisUtil redisUtil;
+    private final PasswordEncoder passwordEncoder;
     private static final long AUTH_CODE_EXPIRE_DURATION_IN_MILLISECONDS = 10 * 60 * 1000L;
     private static final long TEMPORARY_EMAIL_AUTH_IN_MILLISECONDS = 10 * 60 * 1000L;
     private static final String AUTH_CODE_KEY_PREFIX = "authCode:";
@@ -40,7 +42,7 @@ public class EmailService {
 
         Account account = optionalAccount.get();
         String tempPassword = PasswordUtil.generateRandomPassword(10);
-        account.updatePassword(tempPassword);
+        account.updatePassword(passwordEncoder.encode(tempPassword));
         String subject = "[필름덤즈] 임시 비밀번호를 발송해 드립니다.";
         String content = getTempPasswordEmailContent(tempPassword);
         asyncEmailSendService.sendEmail(email, subject, content, true, false);

--- a/src/main/java/com/filmdoms/community/comment/service/CommentService.java
+++ b/src/main/java/com/filmdoms/community/comment/service/CommentService.java
@@ -110,7 +110,8 @@ public class CommentService {
     public void deleteComment(Long commentId, AccountDto accountDto) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_COMMENT_ID));
-
+        if (comment.getAuthor() == null)
+            throw new ApplicationException(ErrorCode.DELETED_COMMENT);
         //ACTIVE 상태인 댓글만 삭제 가능
         checkCommentStatus(comment);
 

--- a/src/main/java/com/filmdoms/community/exception/ErrorCode.java
+++ b/src/main/java/com/filmdoms/community/exception/ErrorCode.java
@@ -51,7 +51,9 @@ public enum ErrorCode {
     SOCIAL_LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인에 실패했습니다."),
     INACTIVE_ACCOUNT(HttpStatus.BAD_REQUEST, "비활성화된 계정입니다."),
     DELETED_ACCOUNT(HttpStatus.BAD_REQUEST, "삭제된 계정입니다."),
+    DELETED_COMMENT(HttpStatus.BAD_REQUEST,"이미 삭제된 댓글입니다"),
     CATEGORY_DOES_NOT_MATCH(HttpStatus.BAD_REQUEST, "카테고리가 일치하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
* 기본 프로필 이미지를 변경하였습니다.
* 댓글 삭제 관련해서 에러코드가 빠져있어서 추가하였습니다.
* 임시 비밀번호 발급 시 PasswordEncoder 사용하지 않아 로그인이 실패한 점을 수정하였습니다.
