### PR TITLE
삭제된 댓글, 그렇지 않은 댓글 보여주는 방식 변경, Guest 이메일 주소 요청 응답 추가

### DIFF
--- a/src/main/java/com/filmdoms/community/account/controller/AccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AccountController.java
@@ -127,6 +127,16 @@ public class AccountController {
         return Response.success();
     }
 
+    @GetMapping("/oauth/profile")
+    public Response guestUserProfileRequest(@AuthenticationPrincipal AccountDto accountDto) {
+        return Response.success(accountService.readAccount(accountDto));
+    }
+
+    @GetMapping("/oauth/profile/email")
+    public Response guestUserEmailRequest(@AuthenticationPrincipal AccountDto accountDto) {
+        return Response.success(accountService.readAccount(accountDto));
+    }
+
     @GetMapping("/check/nickname")
     public Response<CheckDuplicateResponseDto> isUsernameDuplicate(@RequestParam String nickname) {
         return Response.success(new CheckDuplicateResponseDto(accountService.isNicknameDuplicate(nickname)));

--- a/src/main/java/com/filmdoms/community/account/controller/AdminAccountController.java
+++ b/src/main/java/com/filmdoms/community/account/controller/AdminAccountController.java
@@ -24,4 +24,11 @@ public class AdminAccountController {
         return Response.success();
 
     }
+
+    @DeleteMapping("/account/suspend/{accountId}")
+    public Response userSuspendRequest(@PathVariable Long accountId, @AuthenticationPrincipal AccountDto accountDto)
+    {
+        return adminAccountService.suspendUser(accountId);
+    }
+
 }

--- a/src/main/java/com/filmdoms/community/account/service/AdminAccountService.java
+++ b/src/main/java/com/filmdoms/community/account/service/AdminAccountService.java
@@ -3,11 +3,17 @@ package com.filmdoms.community.account.service;
 import com.filmdoms.community.account.data.dto.response.Response;
 import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.account.repository.AccountRepository;
+import com.filmdoms.community.article.data.constant.PostStatus;
+import com.filmdoms.community.article.repository.ArticleRepository;
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
+import com.filmdoms.community.comment.repository.CommentRepository;
+import com.filmdoms.community.exception.ApplicationException;
 import com.filmdoms.community.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -17,6 +23,8 @@ public class AdminAccountService {
 
     private final AccountService accountService;
     private final AccountRepository accountRepository;
+    private final ArticleRepository articleRepository;
+    private final CommentRepository commentRepository;
 
     public Response deleteAccount(Long accountId) {
         Optional<Account> optionalUserAccount = accountRepository.findById(accountId);
@@ -25,6 +33,18 @@ public class AdminAccountService {
             return Response.success();
         }
         return Response.error(ErrorCode.USER_NOT_EXIST.getMessage());
+    }
+
+    public Response suspendUser(Long accountId){
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(()->new ApplicationException(ErrorCode.USER_NOT_FOUND));
+        articleRepository.updateArticlesPostStatus(account, PostStatus.DELETED);
+        commentRepository.updateCommentPostStatus(account, CommentStatus.DELETED);
+        account.updateStatusToDeleted(LocalDateTime.now());
+        accountRepository.save(account);
+
+        return Response.success();
     }
 
 }

--- a/src/main/java/com/filmdoms/community/account/service/TokenAuthenticationService.java
+++ b/src/main/java/com/filmdoms/community/account/service/TokenAuthenticationService.java
@@ -33,8 +33,6 @@ public class TokenAuthenticationService {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
-        accountStatusCheck.checkAccountStatus(account);
-
         return AccountDto.from(account);
     }
 }

--- a/src/main/java/com/filmdoms/community/article/data/dto/response/mainpage/MovieAndRecentMainPageResponseDto.java
+++ b/src/main/java/com/filmdoms/community/article/data/dto/response/mainpage/MovieAndRecentMainPageResponseDto.java
@@ -1,6 +1,7 @@
 package com.filmdoms.community.article.data.dto.response.mainpage;
 
 import com.filmdoms.community.article.data.entity.Article;
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
 import lombok.Getter;
 
 /**
@@ -8,11 +9,12 @@ import lombok.Getter;
  */
 @Getter
 public class MovieAndRecentMainPageResponseDto extends ParentMainPageResponseDto { //recent, movie 메인페이지
-    private int commentCount;
+    private Long commentCount;
 
     private MovieAndRecentMainPageResponseDto(Article article) {
         super(article);
-        this.commentCount = article.getComments().size();
+        this.commentCount = article.getComments()
+                .stream().filter(comment -> comment.getStatus() == CommentStatus.ACTIVE).count();
     }
 
     public static MovieAndRecentMainPageResponseDto from(Article article) {

--- a/src/main/java/com/filmdoms/community/article/data/entity/Article.java
+++ b/src/main/java/com/filmdoms/community/article/data/entity/Article.java
@@ -44,7 +44,7 @@ public class Article extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Content content;
 
-    @Formula("(select count(*) from comment c where c.article_id = id)")
+    @Formula("(select count(*) from comment c where c.article_id = id and c.status = 'ACTIVE')")
     private int commentCount;
 
     @OneToMany(mappedBy = "article")

--- a/src/main/java/com/filmdoms/community/comment/data/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/filmdoms/community/comment/data/dto/response/CommentResponseDto.java
@@ -29,24 +29,18 @@ public class CommentResponseDto {
         this.updatedAt = ZonedDateTime.of(comment.getDateLastModified(), ZoneId.systemDefault()).toInstant().toEpochMilli();
         this.isManagerComment = comment.isManagerComment();
 
-        if (comment.getStatus() == CommentStatus.ACTIVE) {
-            this.content = comment.getContent();
-            this.status = comment.getStatus();
-            this.likes = comment.getVoteCount();
-            if (comment.getAuthor() != null)
-                this.author = DetailPageAccountResponseDto.from(comment.getAuthor());
-            else
-                this.author = null;
-        } else {
+        if (comment.getAuthor() == null || comment.getStatus() == CommentStatus.DELETED) {
             this.content = "삭제된 댓글입니다.";
             this.status = comment.getStatus();
             this.likes = 0;
             this.author = DetailPageAccountResponseDto.makeMockAccount();
+        } else {
+            this.content = comment.getContent();
+            this.status = comment.getStatus();
+            this.likes = comment.getVoteCount();
+            this.author = DetailPageAccountResponseDto.from(comment.getAuthor());
         }
-
-
     }
-
     public static CommentResponseDto from(Comment comment) {
         return new CommentResponseDto(comment);
     }

--- a/src/main/java/com/filmdoms/community/comment/data/dto/response/DetailPageCommentResponseDto.java
+++ b/src/main/java/com/filmdoms/community/comment/data/dto/response/DetailPageCommentResponseDto.java
@@ -1,5 +1,6 @@
 package com.filmdoms.community.comment.data.dto.response;
 
+import com.filmdoms.community.comment.data.dto.constant.CommentStatus;
 import com.filmdoms.community.comment.data.entity.Comment;
 import lombok.Getter;
 
@@ -8,12 +9,12 @@ import java.util.List;
 @Getter
 public class DetailPageCommentResponseDto {
 
-    private int commentCount;
+    private Long commentCount;
 
     private List<ParentCommentResponseDto> comments;
 
     private DetailPageCommentResponseDto(List<Comment> comments) {
-        this.commentCount = comments.size();
+        this.commentCount = comments.stream().filter(comment -> comment.getStatus() == CommentStatus.ACTIVE).count();
         this.comments = ParentCommentResponseDto.convert(comments);
     }
 

--- a/src/main/java/com/filmdoms/community/comment/data/dto/response/ParentCommentResponseDto.java
+++ b/src/main/java/com/filmdoms/community/comment/data/dto/response/ParentCommentResponseDto.java
@@ -34,12 +34,15 @@ public class ParentCommentResponseDto extends CommentResponseDto {
                 .collect(partitioningBy(comment -> comment.getParentComment() == null, toList())); //부모 댓글 여부로 분류
         //isParentComment={true=부모댓글 리스트(생성순 정렬), false=자식댓글 리스트(생성순 정렬)}
 
-        Map<Comment, List<CommentResponseDto>> parentToChildren = isParentComment.get(false).stream().filter(comment -> comment.getStatus() == CommentStatus.ACTIVE)
+        Map<Comment, List<CommentResponseDto>> parentToChildren = isParentComment.get(false).stream()
                 .collect(groupingBy(Comment::getParentComment, mapping(CommentResponseDto::from, toList()))); //자식 댓글을 부모 댓글을 키로 그룹화하고, DTO로 변환
         //parentToChildren={ 부모댓글1=부모댓글1의 자식댓글 DTO 리스트, 부모댓글2=부모댓글2의 자식댓글 DTO 리스트, ...} (자식댓글이 없는 부모댓글은 값으로 null을 가짐)
 
         return isParentComment.get(true).stream()
-                .map(comment -> ParentCommentResponseDto.from(comment, parentToChildren.get(comment))) //부모댓글, 자식댓글 DTO리스트를 이용하여 부모댓글 DTO로 변환
+                .map(comment -> ParentCommentResponseDto.from(comment, parentToChildren.get(comment)))
+                //부모댓글, 자식댓글 DTO리스트를 이용하여 부모댓글 DTO로 변환
+                .filter(parentCommentResponseDto -> !(parentCommentResponseDto.getStatus() == CommentStatus.DELETED && parentCommentResponseDto.getChildComments() == null))
+                // 삭제된 댓글이면서 자식이 없는 부모댓글 필터링
                 .collect(toList()); //최종적으로 부모댓글 리스트가 완성되고, 각각의 부모댓글은 자식댓글 DTO 리스트를 내부에 가지고 있음 (없다면 childComments 필드가 null로 설정됨)
     }
 }

--- a/src/main/java/com/filmdoms/community/comment/repository/CommentVoteRepository.java
+++ b/src/main/java/com/filmdoms/community/comment/repository/CommentVoteRepository.java
@@ -1,5 +1,6 @@
 package com.filmdoms.community.comment.repository;
 
+import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.comment.data.entity.Comment;
 import com.filmdoms.community.comment.data.entity.CommentVote;
 import com.filmdoms.community.comment.data.entity.CommentVoteKey;
@@ -19,4 +20,10 @@ public interface CommentVoteRepository extends JpaRepository<CommentVote, Commen
     @Query("DELETE FROM CommentVote cv " +
             "WHERE cv.voteKey.comment IN :comments")
     void deleteByComments(@Param("comments") List<Comment> comments);
+
+    @Modifying
+    @Query("DELETE FROM CommentVote cv " +
+            "WHERE cv.voteKey.account =:account")
+    void deleteByAccount(@Param("account") Account account);
+
 }

--- a/src/main/java/com/filmdoms/community/config/SecurityConfig.java
+++ b/src/main/java/com/filmdoms/community/config/SecurityConfig.java
@@ -48,6 +48,8 @@ public class SecurityConfig {
                         // localhost:8080/h2-console 사용하기 위한 설정
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/account/oauth").hasRole("GUEST")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/account/oauth/profile").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/account/oauth/profile/email").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/account/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/account/profile").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/account/profile/article").authenticated()

--- a/src/main/java/com/filmdoms/community/vote/repository/VoteRepository.java
+++ b/src/main/java/com/filmdoms/community/vote/repository/VoteRepository.java
@@ -1,15 +1,15 @@
 package com.filmdoms.community.vote.repository;
 
+import com.filmdoms.community.account.data.entity.Account;
 import com.filmdoms.community.article.data.entity.Article;
 import com.filmdoms.community.vote.data.entity.Vote;
 import com.filmdoms.community.vote.data.entity.VoteKey;
-
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface VoteRepository extends JpaRepository<Vote, VoteKey> {
 
@@ -19,4 +19,9 @@ public interface VoteRepository extends JpaRepository<Vote, VoteKey> {
     @Query("DELETE FROM Vote v " +
             "WHERE v.voteKey.article = :article")
     void deleteByArticle(@Param("article") Article article);
+
+    @Modifying
+    @Query("DELETE FROM Vote v " +
+            "WHERE v.voteKey.account =:account")
+    void deleteByAccount(@Param("account") Account account);
 }


### PR DESCRIPTION
크게 총 5가지가 변경되었습니다.

**1. 삭제된 댓글과 그렇지 않은 댓글 보여주는 방식을 결정했습니다.**
Deleted 된 댓글은 서비스에서 보여주지 않습니다!
기존 댓글 갯수에서 Deleted된 댓글 갯수까지 카운팅 되기 때문에 댓글 수와 실제 댓글 수가 맞지 않는 현상이 있었습니다.
따라서 댓글을 전부 가져온 뒤, 자식 댓글이 Deleted상태인 댓글은 댓글 생성에서 아예 제외하고 댓글을 만들게 변경하였습니다.

또한 삭제된 댓글입니다. 가 보여지는 경우는 부모 댓글에 자식 댓글이 달려있는 경우에 보여져야 하는데, 자식 댓글이 없는 경우에 부모 댓글이 삭제 처리된 경우( 이 경우는 회원 탈퇴시에 발생됩니다) 자식 댓글이 없는데도 삭제된 댓글입니다가 보여져 미관상 좋지 않게 되는 것을 확인했고
지금은 단일 리스트이기 때문에 부모에 자식이 있는지 없는지를 부모가 확인이 불가능 합니다
따라서 다 만들어진 댓글에서 자식 댓글이 없는 경우를 필터링 하도록 변경하였습니다.

**2. 비회원 이메일 요청 응답을 구현하였습니다.**
소셜 로그인시 Guest 상태가 되는데 이때 회원 가입시에 이메일이 보여져야 합니다. 따라서 해당 이메일 요청을 받는 컨트롤러 메서드를 생성하였습니다.

**3. 관리자가 사용자를 비활성화 처리 할 수 있는 요청을 만들었습니다.**
회원 탈퇴 테스트 겸, 악성 사용자가 활동하는 경우에 비활성화 처리를 임의로 시켜야 된다고 생각하여 생성하였습니다~!

**4. 계정 삭제시 모든 추천을 삭제 하는 쿼리를 추가했습니다. **
기존 삭제 코드에서, 남의 글에 추천을 하거나 남의 덧글에 추천을 하는 경우가 남아있어 계정 삭제가 진행되지 않았는데
그 부분 계정으로 찾아서 삭제하는 부분을 추가했습니다~!

**5. checkAccountStatus 가 토큰 인증 서비스에 들어있던 부분을 삭제하였습니다.**
비활성화 처리가 되고 토큰 인증 서비스 요청이 들어가면 다시 사용자가 활성화 처리가 되어버려 비활성화가 되지 않는 것을 확인했습니다. 따라서 인증 서비스의 checkAccountStatus는 삭제했습니다.
